### PR TITLE
keep index.html file

### DIFF
--- a/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_00.md
+++ b/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_00.md
@@ -231,17 +231,7 @@ Importing the root module every time looks like a repetitive task.
 Here comes some good news — the Angular 2 package recognizes the file named `app.ts`.
 If you have one in the app root folder, the package will import it for you without even having to ask.
 
-Even more, if you called your app selector — `app`, you can get rid of `index.html` altogether.
-The package adds default layout with the `<app>` tag automatically as follows:
-
-    <body>
-        <app></app>
-    </body>
-
-> Note: default layout is added only when there are no any other HTML files
-> with `head` or `body` tags.
-
-So lets remove `index.html` for now and run the app:
+Let's run the app:
 
     $ meteor
 


### PR DESCRIPTION
You'll have to add an index.html in Meteor 1.3.
Otherwise, the console will show the error:

> EXCEPTION: The selector "app" did not match any elements
> EXCEPTION: Error: Uncaught (in promise): The selector "app" did not match any elements
