### PR TITLE
remove "for" to make the comparison clear

### DIFF
--- a/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_06.md
+++ b/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_06.md
@@ -46,13 +46,13 @@ But unlike a form Control, NgModel has some limitations, e.g., it doesn't suppor
 If you need to validate your form, you can still combine `ngModel` directives with a form model assigned to the `ngFormModel` directive, like this:
 
     <form #f="ngForm" [ngFormModel]="partyForm">
-      <label for="name">Name</label>
+      <label>Name</label>
       <input type="text" ngControl="name" [(ngModel)]="party.name">
 
-      <label for="description">Description</label>
+      <label>Description</label>
       <input type="text" ngControl="description" [(ngModel)]="party.description">
 
-      <label for="location">Location</label>
+      <label>Location</label>
       <input type="text" ngControl="location" [(ngModel)]="party.location">
 
       <button type="submit">Save</button>


### PR DESCRIPTION
Let's keep this clean, because in step **6.3 Bind party to form inputs**, `for` does not exist.
And what we want in this block of codes is letting people know the difference between
`<input type="text" ngControl="name" [(ngModel)]="party.name">`
and
`<input type="text" [(ngModel)]="party.name">`

After removing "for", the only difference of these two blocks of codes is `ngControl`, the comparison is more clear.
