### PR TITLE
add RouterLink dependency

### DIFF
--- a/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_06.md
+++ b/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_06.md
@@ -20,7 +20,7 @@ Let's change `party-details.html` into a form, so that we can edit the party det
 
 {{> DiffBox tutorialName="meteor-angular2-socially" step="6.2"}}
 
-Notice we have a routerLink button on the page that redirects back to the list (from our previous step's challenge). Don't forget to load all required dependencies.
+Notice we have a routerLink button on the page that redirects back to the list (from our previous step's challenge). Don't forget to load the required dependency: adding `import {RouterLink} from 'angular2/router';` on the top of **party-details.ts** and then adding `directives: [RouterLink]` inside of the `@Component`.
 
 ## ngModel
 


### PR DESCRIPTION
The step adding RouterLink dependency in **party-details.ts** is missing. (It is not in Step 5 - Routing & Multiple Views and also not in Step 6 - Bind one object)

When I follow the tutorial, I got the error:

> Template parse errors: Can't bind to 'routerLink' since it isn't a known native property

After adding, it is fixed.
