### PR TITLE
Socially-1 - steps 20, 21 + support for Meteor@1.3.2

### DIFF
--- a/client/content/tutorials/socially/angular1/tutorials.socially.angular1.step_17.md
+++ b/client/content/tutorials/socially/angular1/tutorials.socially.angular1.step_17.md
@@ -11,9 +11,7 @@ First, we need to add Boostrap 4 to our project - so let's do that.
 
 Run the following command in your Terminal:
 
-    $ meteor npm install bootstrap4-webpack-package --save
-
-> At this time, you cannot use the original Boostrap 4 package from NPM, and a wrapper is needed. Meteor 1.3.2 may resolve this issue. [Click for more information about this issue](https://github.com/meteor/meteor/issues/6098).
+    $ meteor npm install bootstrap@4.0.0-alpha.2 --save
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="17.4"}}
 

--- a/client/content/tutorials/socially/angular1/tutorials.socially.angular1.step_18.md
+++ b/client/content/tutorials/socially/angular1/tutorials.socially.angular1.step_18.md
@@ -10,7 +10,7 @@ Angular-material is an Angular 1 implementation of Google's [Material Design spe
 
 To start, first we have to remove bootstrap from our application. Type in the console:
 
-    meteor npm uninstall bootstrap4-webpack-package --save
+    meteor npm uninstall bootstrap --save
 
 We should also remove dependency from the main.js file:
 

--- a/client/content/tutorials/socially/angular1/tutorials.socially.angular1.step_20.md
+++ b/client/content/tutorials/socially/angular1/tutorials.socially.angular1.step_20.md
@@ -3,234 +3,268 @@
 
 In this step we are going to add the ability to upload images into our app, and also sorting and naming them.
 
-Angular-Meteor can use Meteor [CollectionFS](https://github.com/CollectionFS/Meteor-CollectionFS) which is a suite of Meteor packages that together provide a complete file management solution including uploading, downloading, storage, synchronization, manipulation, and copying.
+Angular-Meteor can use Meteor [UploadFS](https://github.com/jalik/jalik-ufs) which is a suite of Meteor packages that together provide a complete file management solution including uploading, downloading, storage, synchronization, manipulation, and copying.
 
-It supports several storage adapters for saving files to the local filesystem, GridFS, Amazon S3, or DropBox,  and additional storage adapters can be created.
+It supports several storage adapters for saving files to the local filesystem, GridFS and additional storage adapters can be created.
 
 The process is very similar for handling any other MongoDB Collection!
 
 So let's add image upload to our app!
 
 
-We will start by adding CollectionFS to our project, by running the following command:
+We will start by adding UploadFS to our project, by running the following command:
 
-    $ meteor add cfs:standard-packages
+    $ meteor add jalik:ufs
 
-Now, we will decide the storage adapter we want to use. 
+Now, we will decide the storage adapter we want to use.
 In this example, we will use the GridFS as storage adapters, so we will add the adapter by running this command:
 
-    $ meteor add cfs:gridfs
+    $ meteor add jalik:ufs-gridfs
 
-Note: you can find more information about Stores and Storage Adapters on the [CollectionFS](https://github.com/CollectionFS/Meteor-CollectionFS)'s GitHub repository.
+Note: you can find more information about Stores and Storage Adapters on the [UploadFS](https://github.com/jalik/jalik-ufs)'s GitHub repository.
 
-So now we have the CollectionFS support and the storage adapter installed - we still need to create a CollectionFS object to handle our files.
+So now we have the UploadFS support and the storage adapter installed - we still need to create a UploadFS object to handle our files.
 Note that you will need to define the collection as shared resource because you will need to use the collection in both client and server side.
 
-### Creating the CollectionFS
+### Creating the Mongo Collection and UploadFS Store
 
-Let's start by creating `model/images.js` file, and define a regular CollectionFS object called "Images".
-Also we will use the CollectionFS API that allows us to defined auth-rules.
-Finally, We will publish the collection just like any other collection, in order to allow the client to subscribe to those images:
+Let's start by creating `imports/api/images/collection.js` file, and define a Mongo Collection object called "Images". Since we want to be able to make thumbnails we have to create another Collection called "Thumbs".
+
+Also we will use the stadard Mongo Collection API that allows us to defined auth-rules.
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.3"}}
 
-Now let's add a regular subscription to the `images` publication, and also add the `Images` collection as helper:
+We have to create Stores for Images and Thumbs.
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.4"}}
 
-So now we have the collection, We can now create a client-side that handles the images upload.
+Let's explain a bit what happened.
 
-### Image Upload
+* We assigned Stores to their Collections, which is required.
+* We defined names of these Stores.
+* We added filter to ImagesStore so it can receive only images.
+* Every file will be copied to ThumbsStore.
 
-Note that for file upload you can use basic HTML `<input type="file">`  or any other package - you only need the HTML5 File object to be provided.
 
-For our application, we would like to add ability to drag-and-drop images, so we use AngularJS directive that handles file upload and gives us more abilities such as drag & drop, file validation on the client side.
-In this example, I will use [ng-file-upload](https://github.com/danialfarid/ng-file-upload), which have many features for file upload.
-In order to do this, lets add the package to our project:
+Now we can create `index.js` file to export Collections and Stores:
 
-    $ meteor add danialfarid:ng-file-upload
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.5"}}
 
-Now, lets add a dependency in the `app.js` file:
+There is a reason why we called one of the Collections the `Thumbs`!
+
+Since we transfer every uploaded file to ThumbsStore, we can now easily add file manipulations.
+
+Let's resize every file to 32x32:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.6"}}
 
-Now, let's add the usage of `ng-file-upload` to the add new party modal:
+We used `gm` module, let's install it:
 
-{{> DiffBox tutorialName="meteor-angular1-socially" step="20.7"}}
+    $ meteor npm install gm --save
 
-And now let's add some CSS rules to make the upload box look better, and it also create an area for drag & drop:
+### Image upload
+
+Now, let's create the `PartyUpload` component. It will be responsible for cropping and uploading photos.
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.8"}}
 
-And of course, let's import this file:
-
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.9"}}
 
-And now let's add the `addImages` method to our component:
+We want to use it in `PartyAdd`:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.10"}}
 
-> Note that the `addImages` is used in `nfg-change` attribute on html file we just created.
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.11"}}
 
-And that's it! now we can upload images by using drag and drop!
-Just note that the Application UI still don't show the new images we upload... we will add this later.
-Now let's add some more cool features, And make the image uploaded image visible!
+As you can see we used `files` directive. We will create it later. For now, let's only say that this is a two-way data binding.
 
-### Image Crop
 
-One of the most common actions we want to make with pictures is edit them before saving. 
-We will add to our example ability to crop images before uploading them to the server, using [ngImgCrop](https://github.com/alexk111/ngImgCrop/) package.
-So lets start by adding the package to our project:
+Note that for file upload you can use basic HTML `<input type="file">` or any other package - you only need the HTML5 File object to be provided.
 
-    $ meteor add alexk111:ng-img-crop
+For our application, we would like to add ability to drag-and-drop images, so we use AngularJS directive that handles file upload and gives us more abilities such as drag & drop, file validation on the client side. In this example, We will use [`ng-file-upload`](https://github.com/danialfarid/ng-file-upload), which have many features for file upload. In order to do this, let's add the package to our project:
 
-And add a dependency in our module:
+    $ meteor npm install ng-file-upload --save
 
-{{> DiffBox tutorialName="meteor-angular1-socially" step="20.12"}}
-
-We want to perform the crop on the client, before saving it to the `CollectionFS`, so lets get the uploaded image, and instead of saving it to the server - we will get the Data Url of it, and use it in the `ngImgCrop`:
-
-{{> DiffBox tutorialName="meteor-angular1-socially" step="20.15"}}
-
-We took the file object and used HTML5 FileReader API to read the file from the user on the client side, without uploading it to the server.
-Then we saved the DataURI of the image into a variable.
-Next, we will need to use this DataURI with the `ngImgCrop` directive as follow:
+Now, lets add a dependency in the `PartyUpload`:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.13"}}
 
->Moreover we add `ng-hide` to the upload control, in order to hide it, after the user picks an image to crop.
-
-And add some CSS to make it look better:
+Now, let's add the usage of `ng-file-upload`:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.14"}}
 
-And let's add a button that saves the new cropped image.
+Now let's make it better looking:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.16"}}
 
-In order to save, we need to implement `saveCroppedImage()` function. We will use the same `CollectionFS` API we used before - with the `insert` method.
-
-CollectionFS have the ability to receive DataURI and save it, just like a File object. So the implementation looks like that:
+then import new .less file in the `PartyAdd`
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.17"}}
 
-So we take the image object and save it to the CollectionFS and put it in an array we called `images` that will hold the images for the new party.
-
-Then we reset the form by updating the value of `cropImgSrc` variable (we used it in the `ng-hide`).
-
-We also change the login under `addNewParty` method, we take only the `_id` property of the images, because we want to save the id and not the whole image object when saving it.
-
-And we are almost done, Now we have the ability to crop images and then save them using CollectionFS.
-
-We are just missing the display of the uploaded images in our form!
-
-### Display Uploaded Images
-
-Let's add a simple gallery to list the images in the new party form:
+and in the `PartyAddButton`:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.18"}}
 
-And that's it! We just repeated them and used it built-in method called `.url()`!
+And that's it! now we can upload images by using drag and drop!
+Just note that the Application UI still don't show the new images we upload... we will add this later.
+Now let's add some more cool features, And make the uploaded image visible!
 
-Now let's add description to our images!
+### Image Crop
 
-### Images Metadata & Description
+One of the most common actions we want to make with pictures is to edit them before saving.
+We will add to our example ability to crop images before uploading them to the server, using [ngImgCrop](https://github.com/alexk111/ngImgCrop/) package.
+So lets start by adding the package to our project:
 
-Using CollectionFS, we can also save metadata on the files we store.
-In order to do that, we just need to update the `metadata` property of the image object.
-
-In order to do that with really nice and user-friendly ui, I used [angular-xeditable](https://github.com/vitalets/angular-xeditable).
-Lets add the angular-xeditable package to our project:
-
-    $ meteor add vitalets:angular-xeditable
+    $ meteor npm install ng-img-crop --save
 
 And add a dependency in our module:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.20"}}
 
-Now, let's use `angular-xeditable` and add usage under the image:
+We want to perform the crop on the client, before uploading it, so let's get the uploaded image, and instead of saving it to the server - we will get the Data Url of it, and use it in the `ngImgCrop`:
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.15"}}
+
+We took the file object and used HTML5 `FileReader` API to read the file from the user on the client side, without uploading it to the server.
+Then we saved the DataURL of the image into a variable `cropImgSrc`.
+Next, we will need to use this DataURI with the `ngImgCrop` directive as follow:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.21"}}
 
-Due to problem with open issue in [angular-xeditable](https://github.com/vitalets/angular-xeditable/issues/6) 
-We need to change the `form` on `add-new-party-modal.html` into `div` to make the inline editing of `angular-xeditable` work.
+> Moreover we add `ng-hide` to the upload control, in order to hide it, after the user picks an image to crop.
 
-And, of course, implement `updateDescription` function on the parties list scope:
+And add some CSS to make it look better:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.22"}}
 
-> We used the CollectionFS API again, using the `update()` method, and we put the description under the `metadata.description` property.
 
-That's it! Now we have a photo gallery with description for each image!
+Now we need to handle uploading files.
 
-### Sort Images
+Since we're using `DataURL` and we need UploadFS expects `ArrayBuffer` let's add few helper methods.
 
-After we learned how to use CollectionFS metadata and how to update metadata values, we can also add an ability to sort and update the images order.
-To get the ability to sort the images, let's use [angular-sortable-view](https://github.com/kamilkp/angular-sortable-view).
+Add `dataURLToBlob` to converts DataURL to `Blob` object:
 
-Add the package by running this command:
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.23"}}
 
-    $ meteor add netanelgilad:angular-sortable-view
-
-And then add a dependency for the module:
+We have now Blob object so let's convert it to expected `ArrayBuffer` by creating a function called `blobToArrayBuffer`:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.24"}}
 
-The basics of `angular-sortable-view` is to add the `sv-?` attributes to our page, just like the examples in the `angular-sortable-view` repository, So let's do that:
+Now we can take care of uploading by creating a `upload` function:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.25"}}
 
-> We also added `draggable="false"` to prevent the browser's default behavior for dragging images.
+* `dataUrl` is the file we want to upload
+* `name` is a name of the file
+* `resolve` is a callback function that will be invoked on success
+* `reject` is a callback function that will be invoked on error
+* We took `name`, `type` and `size` from Blob object to send these information to `UploadFS.Uploader`
 
-We can also add a highlight to the first image, which we will use as the main image, by adding an indication for that:
+What's left is just to export this method:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.26"}}
 
-And some CSS to make it look better:
+We previously defined two methods: `save()` and `reset()`. Let's implement them using recently created `upload` function:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.27"}}
 
-So now we have image gallery with ability to add images, edit them, add a description and sort.
-Now we just need to add the logic that connect those images with the party we are creating!
+Let's explain the code.
 
-### Link Image To Object
+* The cropped image is under `myCroppedImage` variable so we used it to as the file to be uploaded.
+* We used `currentFile.name` to get name of the file.
+* We used `$bindToContext` on the first callback (`resolve`) to keep it inside digest cycle.
+* We used `console.log` to notify about an error.
+* We created `reset()`` to clear these variables.
 
-So as you know, we have all the images stored in `newParty.images` array, and we changed `addNewParty` method in step 20.17 to save only the ids of the images.
-
-So finally, to display the main image in the parties list, add the following code to the component:
-
-{{> DiffBox tutorialName="meteor-angular1-socially" step="20.29"}}
-
-And implement the `getMainImage` function:
+Last thing to do is to import Images and Thumb on the server-side:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.28"}}
 
-With some CSS rules to make it look better:
+### Display Uploaded Images
+
+Let's create a simple gallery to list the images in the new party form:
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.29"}}
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.30"}}
 
-And that's it!
+We have to somehow get thumbnails to show them in this gallery.
 
-### Thumbnails
-
-Another common usage with image upload, is the ability to save thumbnails of the image as soon as we upload it.
-CollectionFS gives the ability to handle multiple Stores object, and perform manipulations before we save it in each store.
-You can find the full information about image manipulation in the [CollectionFS docs](https://github.com/CollectionFS/Meteor-CollectionFS#image-manipulation).
-
-Also, make sure you add graphicsmagick package by inserting the following line in the terminal :
-
-    $ meteor add cfs:graphicsmagick
-
-For more information, follow the instructions on the [CollectionFS](https://github.com/CollectionFS/Meteor-CollectionFS) GitHub page.
-In order to add ability to save thumbnails, lets add a new store in the `images.js` modal and use `transformWrite` ability:
+Since we keep them in Collections, we have to create proper publications:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.31"}}
 
-So now each image we upload will be saved also as thumbnail.
-All we have to do in order to display the thumbnail instead of the original image is to add a param to `url()` method of File objects and decide which Store to use when creating the URL:
-
 {{> DiffBox tutorialName="meteor-angular1-socially" step="20.32"}}
 
-That's it! Now we added the ability to save thumbnails for the images and use them in the view!
+Now we can implement thumbnails:
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.33"}}
+
+There are few things that need to be explained:
+
+* We subscribed to `thumbs` publication with one argument.
+* We created the `thumbs` helper that fetches all thumbnails of our saved files.
+* Mentioned before `files` variable. It contains identifiers of uploaded files.
+
+### Sort Images
+
+We can also add an ability to sort and update the images order.
+To get the ability to sort the images, let's use [angular-sortable-view](https://github.com/kamilkp/angular-sortable-view).
+
+    $ meteor npm install angular-sortable-view --save
+
+Let's add it as a dependency:
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.35"}}
+
+Implement directives of angular-sortable-view:
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.36"}}
+
+You can now easily change their order.
+
+> Remember! First file is the main file which will be shown on parties list. We will implement it later.
+
+
+Since we have sorting, croping and uploading. We can now add binding we prepared previously:
+
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.37"}}
+### Display party image on the list
+
+As always, we have to create component, let's call it `PartyImage`.
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.38"}}
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.39"}}
+
+As you can see we defined `images` which is a one-way binding that tells to the PartyImage component which images have been uploaded to the party.
+
+> Objects of `Images` and `Thumbs` collections contains `.url` property with absolute url to the file.
+
+Now let's implement it to the `PartiesList` by adding dependency and what is more important, by subscribing `images`. Subscription is needed to fetch defined images.
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.40"}}
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="20.41"}}
+
+And that's it!
+
+
+### Cloud Storage
+
+By storing files in the cloud you can reduce your costs and get a lot of other benefits.
+
+Since this chapter is all about uploading files and UploadFS doesn't have built-in support for cloud services we should mention another library for that.
+
+We recommend you to use [Slingshot](https://github.com/CulturalMe/meteor-slingshot/). You can install it by running:
+
+    $ meteor add edgee:slingshot
+
+It's very easy to use with AWS S3, Google Cloud and other cloud storage services.
+
+From slignshot's repository:
+
+> meteor-slingshot uploads the files directly to the cloud service from the browser without ever exposing your secret access key or any other sensitive data to the client and without requiring public write access to cloud storage to the entire public.
 
 {{/template}}

--- a/client/content/tutorials/socially/angular1/tutorials.socially.angular1.step_21.md
+++ b/client/content/tutorials/socially/angular1/tutorials.socially.angular1.step_21.md
@@ -1,17 +1,11 @@
 {{#template name="tutorials.socially.angular1.step_21.md"}}
 {{> downloadPreviousStep stepName="step_20"}}
 
-This step of the tutorial teaches us how to add mobile support for iOS and Android and how to elegantly reuse code using the Meteor packaging system.
-
-First, let's understand Meteor's packages: 
-- A folder named `packages` under the root directory defines the *local* package of our project. "Local" means packages that we develop ourselves, rather than use existing packages. 
-- We use packages to separate the code that is used for for mobile and web.
+This step of the tutorial teaches us how to add mobile support for iOS and Android and how to elegantly reuse code using the es2015 modules.
 
 In this tutorial's example we will differentiate the login part of the project: in the browser users will login using email and password and in the mobile app users will login with SMS verification.
 
-We create seperate AngularJS modules for mobile and web in order to seperate between this code part - it's a perfect alternative for using `Meteor.isCordova` multiple times!
-
-### Adding mobile support for the project: 
+### Adding mobile support for the project:
 
 To add mobile support, select the platform(s) you want and run the following command:
 
@@ -25,147 +19,93 @@ And now to run in the emulator, run:
     # OR
     $ meteor run android
 
-You can also run in a real mobile device, for more instructions, read [Meteor and Cordova integration](https://github.com/meteor/meteor/wiki/Meteor-Cordova-integration).
+You can also run in a real mobile device, for more instructions, read the ["Mobile" chapter](http://guide.meteor.com/mobile.html) of the Official Meteor Guide.
 
-### creating packages
+### Creating es2015 modules
 
-To work with packages we need to create the `packages` directory:
+We're going to keep the view and the controller for the web under `web.html` and `web.js` and doing the same for `mobile.html` and `mobile.js`.
 
-    $ mkdir packages
+First thing to do is to move the content of `login.html` to `web.html` file:
 
-We will initially work on the package that contains the mobile logic. Let's create the mobile package by running the following command:
+{{> DiffBox tutorialName="meteor-angular1-socially" step="21.2"}}
 
-    $ meteor create --package socially-mobile
+Now we can create a view for a mobile version:
 
-Meteor will create for us a default package. The main file is `package.js` that look like that:
+{{> DiffBox tutorialName="meteor-angular1-socially" step="21.3"}}
 
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.2" filename="packages/socially-mobile/package.js"}}
+As you can see for now there are only three elements:
 
-As with any auto-generated code, we do not always need everything. In this case we will remove the auto generated files that we are not using for now:
+* md-toolbar with a heading
+* md-toolbar to display an error
+* and a link to password reset section
 
-`packages/socially-mobile/socially-mobile-tests.js`
-
-`packages/socially-mobile/socially-mobile.js`
-
-And also remove them from the `package.js` file:
-
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.3" filename="packages/socially-mobile/package.js"}}
-
-The package is ready and can be added to our project running: 
-
-  `$ meteor add socially-mobile`
-
-We make sure that AngularJS and angular-meteor are loaded before our package by adding the following dependency using the `api.use` method:
+Now we have views for both versions. Let's take `Login` class which is component's controller and move it to `web.js`:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="21.4"}}
 
-### Angular Mobile Module 
-
-In this part we will create an Angular module that contains a login route and specific html for mobile. 
-
-We are preserving the same folder structure as we had in the main project, so the files will be located under `client/lib/` inside our pagckage. 
-
-Here are the steps: 
-
-Create the AngularJS module and name it `socially.mobile`:
+Let's create an empty class with the same name but for mobile inside `mobile.js` file:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="21.5"}}
 
-Now let's create a new component for the `login`, under our package:
+We have two modules: web and mobile. Now let's do few things with `login.js`:
+
+* Remove an old `login.html` view.
+* Remove an old `Login` class.
+* Import `Login` classes from `mobile` and `web` modules.
+* Import both recently created views.
+* Create `controller` and `template` variables so they can be used in component definition.
+* Use `Meteor.isCordova` inside conditional statement to set proper value for these variables.
+
+`login.js` file should look like this:
 
 {{> DiffBox tutorialName="meteor-angular1-socially" step="21.6"}}
 
-And it's view, just a dummy view for now:
 
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.7"}}
+### SMS verification
 
-### Add module's files to the package
+As I mentioned before, we're going to use SMS verification to log in a user on the mobile application.
 
-We need to tell our `package.js` to use the files that we created above, so we will use `api.addFiles`.
+There is a package for that!
 
-We also need to add the platform declaration, using the last argument of these functions.
-
-> The available platforms are: `web.browser`, `web.cordova`, `client` (both browser and cordova) and `server`.
-
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.8"}}
-
-Last, we want to load the `socially.mobile` module only in Cordova environment. We can update `app.js` to load the module only when running inside Cordova (`Meteor.isCordova`):
-
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.9"}}
-
-Let's try to run it inside an emulator (I used iOS Simulator on Mac OS X), it should look like that:
-
-{{tutorialImage 'angular1' 'step21_1.png' 500}}
-
-Great! Seems that it is working!
-
-### Angular Browser Module 
-
-We will do a similar process to add support for browser package. The first step is to load another AngularJS module when we run in the browser:
-
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.10"}}
-
-We will create a package again, named `socially-browser`, and remove the default files:
-
-    $ meteor create --package socially-browser
-
-Make some modifications to the `package.js` file, very similar to the mobile package:
-
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.11" filename="packages/socially-browser/package.js"}}
-
-> Note that we load the files only in the `web.browser` platform.
-
-Create the `socially.browser` module:
-
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.11" filename="packages/socially-browser/client/lib/module.js"}}
-
-Add the browser login stub view:
-
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.11" filename="packages/socially-browser/client/auth/login/login.html"}}
-
-And the stub component:
-
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.11" filename="packages/socially-browser/client/auth/login/login.component.js"}}
-
-Add the browser package to our project:
-
-  $ meteor add socially-browser
-
-### Implement Browser Login
-
-We will use the existing code for our web login. That means 2 things: 
-- Copying the original login view file from `client/users/login/login.html` to our package view (`login.html`):
-
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.14"}}
-
-- Moving the current `login` component from `client/users/login/login.component.js` to our package, and update the module's name for this component:
-
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.13"}}
-
-> We can also delete `client/users/login/login.html` and `client/users/login/login.component.js` files. It is no longer needed!
-
-> **A note on package name prefixing**: It is important to note that if you include a prefix in the declaration of your package name (as seen in `21.11  Create socially-browser package`) then you should remember to include this prefix in absolute path references elsewhere. E.g. if package name is declared as `name: 'my-prefix:socially-browser'` then the templateUrl in the above code snippet would need to read `templateUrl: '/packages/my-prefix:socially-browser/client/auth/login/login.html'`
-
-### Implement Mobile Login
-
-We need to take care of the login view for mobile only. We will add a view with two steps: 
-- Capture the user's phone number 
-- Enter the SMS code verification
-
-We will use an external package that extends Meteor's Accounts, called `accounts-phone` that verifies phone number with SMS message, so let's add it:
+We will use an external package that extends Meteor's Accounts, called [accounts-phone](https://atmospherejs.com/okland/accounts-phone) that verifies phone number with SMS message, so let's add it:
 
     $ meteor add okland:accounts-phone
 
-And now we will add to the mobile package a `login` component logic that uses Accounts-Phone package to verify our phone number:
+> Note that in development mode - the SMS will not be sent - and the verification code will be printed to the Meteor log.
 
-{{> DiffBox tutorialName="meteor-angular1-socially" step="21.17"}}
+> Latest release of accounts-phone won't work with Meteor 1.3.
+Until this changes you can use `mys:accounts-phone` which fixes that issue.
 
-> Note that in development mode - the SMS will not sent - and the verification code will be printed to the Meteor log.
+This is a two-step process so let's implement the first one:
 
-And that's it! we got a different component for each platform!
+{{> DiffBox tutorialName="meteor-angular1-socially" step="21.9"}}
+
+Let me explain what happened:
+
+* We used `isStepTwo` variable to check in which step we currently are.
+* `verificationCode` will be used in the second step.
+* `Accounts.requestPhoneVerification` is to verify a phone number.
+* `this.isStepTwo = true;` is to mark that we moved to the second step
+
+Now we can implement it in the `mobile.html`:
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="21.10"}}
+
+Let's move to second step which is the code verification. We have to create a method for this:
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="21.11"}}
+
+* We used `$state` service to redirect user to `parties` after successful verification.
+* `Accounts.verifyPhone` is to verify a code with a phone number.
+
+Add it to the `mobile.html`:
+
+{{> DiffBox tutorialName="meteor-angular1-socially" step="21.12"}}
+
+And that's it! We've got a the same component that behaves differently for each platform!
 
 ## Summary
 
-In this tutorial we showed how to make our code behave differently in mobile and web platforms and load different files using Meteor's packaging system. We did this by creating separate AngularJS modules with specific code for mobile and web, and loading them into the client based on the platform that runs the application. 
+In this tutorial we showed how to make our code behave differently in mobile and web platforms. We did this by creating separate es2015 modules with specific code for mobile and web, and using them based on the platform that runs the application.
 
 {{/template}}

--- a/client/content/tutorials/socially/patches/meteor-angular1-socially.multi.patch
+++ b/client/content/tutorials/socially/patches/meteor-angular1-socially.multi.patch
@@ -1,7 +1,7 @@
-From 522d88091b33497a47c969b7a82027dbdd9fffe6 Mon Sep 17 00:00:00 2001
+From 420461d552ad3989a65385b2f735f6580dc27436 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:15:57 +0200
-Subject: [PATCH 001/303] Step 0.2: Remove project files
+Subject: [PATCH 001/356] Step 0.2: Remove project files
 
 ---
  client/main.css  |  1 -
@@ -96,10 +96,10 @@ index 31a9e0e..0000000
 2.5.0
 
 
-From 86ef8ff6f30975248cea9137d2081f2b12294f0d Mon Sep 17 00:00:00 2001
+From cb7f716926bada91e1ade2d2fe201e0af49036ca Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:29:56 +0200
-Subject: [PATCH 002/303] Step 0.3: Create an empty html file
+Subject: [PATCH 002/356] Step 0.3: Create an empty html file
 
 ---
  client/index.html | 3 +++
@@ -119,10 +119,10 @@ index 0000000..ef412ef
 2.5.0
 
 
-From 164fc5da12c5761b8bd926e4637ba012f73fd6ec Mon Sep 17 00:00:00 2001
+From b3768c3c558fdc7cab8b57112758806e9ae41e4d Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:33:17 +0200
-Subject: [PATCH 003/303] Step 0.4: Remove `blaze-html-templates` and
+Subject: [PATCH 003/356] Step 0.4: Remove `blaze-html-templates` and
  `ecmascript`
 
 ---
@@ -151,38 +151,38 @@ index d4c8001..c370be2 100644
  autopublish             # Publish all data to the clients (for prototyping)
  insecure                # Allow all DB writes from clients (for prototyping)
 diff --git a/.meteor/versions b/.meteor/versions
-index 1430419..a6fa57c 100644
+index 726e24a..e2742f2 100644
 --- a/.meteor/versions
 +++ b/.meteor/versions
-@@ -6,11 +6,8 @@ babel-runtime@0.1.6
- base64@1.0.6
- binary-heap@1.0.6
- blaze@2.1.5
--blaze-html-templates@1.0.2
- blaze-tools@1.0.6
- boilerplate-generator@1.0.6
--caching-compiler@1.0.2
--caching-html-compiler@1.0.4
- callback-hook@1.0.6
- check@1.1.2
- ddp@1.2.3
-@@ -59,8 +56,6 @@ spacebars@1.0.9
- spacebars-compiler@1.0.9
- standard-minifier-css@1.0.4
- standard-minifier-js@1.0.4
--templating@1.1.7
--templating-tools@1.0.2
- tracker@1.0.11
- ui@1.0.9
- underscore@1.0.6
+@@ -6,11 +6,8 @@ babel-runtime@0.1.8
+ base64@1.0.8
+ binary-heap@1.0.8
+ blaze@2.1.7
+-blaze-html-templates@1.0.4
+ blaze-tools@1.0.8
+ boilerplate-generator@1.0.8
+-caching-compiler@1.0.4
+-caching-html-compiler@1.0.6
+ callback-hook@1.0.8
+ check@1.2.1
+ ddp@1.2.5
+@@ -59,8 +56,6 @@ spacebars@1.0.11
+ spacebars-compiler@1.0.11
+ standard-minifier-css@1.0.6
+ standard-minifier-js@1.0.6
+-templating@1.1.9
+-templating-tools@1.0.4
+ tracker@1.0.13
+ ui@1.0.11
+ underscore@1.0.8
 -- 
 2.5.0
 
 
-From 009498f9b0399871c2a32e653ac80eb32085a310 Mon Sep 17 00:00:00 2001
+From ebeed7ec9825d5ebbe2ff338d936e5da2ab17038 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:35:22 +0200
-Subject: [PATCH 004/303] Step 0.5: Add `angular-templates` and
+Subject: [PATCH 004/356] Step 0.5: Add `angular-templates` and
  `pbastowski:angular-babel`
 
 ---
@@ -201,48 +201,48 @@ index c370be2..d74ee49 100644
 +pbastowski:angular-babel
 +angular-templates
 diff --git a/.meteor/versions b/.meteor/versions
-index a6fa57c..a82d518 100644
+index e2742f2..5a2d576 100644
 --- a/.meteor/versions
 +++ b/.meteor/versions
 @@ -1,4 +1,5 @@
- allow-deny@1.0.2
+ allow-deny@1.0.4
 +angular-templates@1.0.2
- autopublish@1.0.5
- autoupdate@1.2.6
- babel-compiler@6.5.2
-@@ -8,6 +9,8 @@ binary-heap@1.0.6
- blaze@2.1.5
- blaze-tools@1.0.6
- boilerplate-generator@1.0.6
+ autopublish@1.0.7
+ autoupdate@1.2.8
+ babel-compiler@6.6.4
+@@ -8,6 +9,8 @@ binary-heap@1.0.8
+ blaze@2.1.7
+ blaze-tools@1.0.8
+ boilerplate-generator@1.0.8
 +caching-compiler@1.0.2
 +caching-html-compiler@1.0.4
- callback-hook@1.0.6
- check@1.1.2
- ddp@1.2.3
-@@ -46,6 +49,7 @@ mongo-id@1.0.2
- npm-mongo@1.4.41
- observe-sequence@1.0.9
- ordered-dict@1.0.5
+ callback-hook@1.0.8
+ check@1.2.1
+ ddp@1.2.5
+@@ -46,6 +49,7 @@ mongo-id@1.0.4
+ npm-mongo@1.4.43
+ observe-sequence@1.0.11
+ ordered-dict@1.0.7
 +pbastowski:angular-babel@1.3.2
- promise@0.6.5
- random@1.0.7
- reactive-var@1.0.7
-@@ -56,6 +60,7 @@ spacebars@1.0.9
- spacebars-compiler@1.0.9
- standard-minifier-css@1.0.4
- standard-minifier-js@1.0.4
+ promise@0.6.7
+ random@1.0.9
+ reactive-var@1.0.9
+@@ -56,6 +60,7 @@ spacebars@1.0.11
+ spacebars-compiler@1.0.11
+ standard-minifier-css@1.0.6
+ standard-minifier-js@1.0.6
 +templating-tools@1.0.2
- tracker@1.0.11
- ui@1.0.9
- underscore@1.0.6
+ tracker@1.0.13
+ ui@1.0.11
+ underscore@1.0.8
 -- 
 2.5.0
 
 
-From fbd4e547a064bd6c60fb1fad3b1d2ca73f5fe458 Mon Sep 17 00:00:00 2001
+From 5cb3c9f37e360f82ec817748861cbad85bf16a42 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:36:09 +0200
-Subject: [PATCH 005/303] Step 0.6: Add `angular` and `angular-meteor`
+Subject: [PATCH 005/356] Step 0.6: Add `angular` and `angular-meteor`
 
 ---
  package.json | 2 ++
@@ -265,10 +265,10 @@ index 196e6e1..1fdb919 100644
 2.5.0
 
 
-From 7048c8aff2c0aa2b95a992c8ceb106085b7d8616 Mon Sep 17 00:00:00 2001
+From 0768c2322fc56ab927082c9fdfac0bfb40a6caaf Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:38:27 +0200
-Subject: [PATCH 006/303] Step 0.7: Move the main content to a new file
+Subject: [PATCH 006/356] Step 0.7: Move the main content to a new file
 
 ---
  client/main.html | 1 +
@@ -286,10 +286,10 @@ index 0000000..79ed426
 2.5.0
 
 
-From 0da5aeaf919095c5b0bc7807ab4f9e44f360394b Mon Sep 17 00:00:00 2001
+From 84e9a1492a4c32b9c4fedfb9e75acb6886aae83c Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:39:02 +0200
-Subject: [PATCH 007/303] Step 0.8: Add `ng-include` that loads the main.html
+Subject: [PATCH 007/356] Step 0.8: Add `ng-include` that loads the main.html
  file
 
 ---
@@ -309,10 +309,10 @@ index ef412ef..6378317 100644
 2.5.0
 
 
-From 2a073bd32ddc7b2816a7783694dd00ff97f8db6a Mon Sep 17 00:00:00 2001
+From fe7b2fbf1e404f15ec15ea11c75ff30d6ece07de Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:41:54 +0200
-Subject: [PATCH 008/303] Step 0.9: Add main.js with angular module
+Subject: [PATCH 008/356] Step 0.9: Add main.js with angular module
 
 ---
  client/main.js | 6 ++++++
@@ -335,10 +335,10 @@ index 0000000..558ad57
 2.5.0
 
 
-From 1678de9ee518391815245514ac29cc82999c3d11 Mon Sep 17 00:00:00 2001
+From 5fac685d6a33442a80d5c2ab1e6e58744879152a Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:42:29 +0200
-Subject: [PATCH 009/303] Step 0.10: Add usage of `ng-app` in our app
+Subject: [PATCH 009/356] Step 0.10: Add usage of `ng-app` in our app
 
 ---
  client/index.html | 2 +-
@@ -357,10 +357,10 @@ index 6378317..f6b9ac4 100644
 2.5.0
 
 
-From 49bd40bc8b62f0dd78e1d98443b5da9c2b79d222 Mon Sep 17 00:00:00 2001
+From 5fac81e7b55fba2acc4f40dab69316c1cd49a101 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:47:16 +0200
-Subject: [PATCH 010/303] Step 0.11: Add some AngularJS code !
+Subject: [PATCH 010/356] Step 0.11: Add some AngularJS code !
 
 ---
  client/main.html | 2 +-
@@ -377,10 +377,10 @@ index 79ed426..a9c8ddc 100644
 2.5.0
 
 
-From 58311374e0e627dfb5a1f26b23f9fc7df7f927e8 Mon Sep 17 00:00:00 2001
+From bc3f6a411ef781e97e90f47fac9621564a02f589 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:48:04 +0200
-Subject: [PATCH 011/303] Step 1.1: Add some static HTML the to main page
+Subject: [PATCH 011/356] Step 1.1: Add some static HTML the to main page
 
 ---
  client/main.html | 15 ++++++++++++++-
@@ -410,10 +410,10 @@ index a9c8ddc..dd1ef68 100644
 2.5.0
 
 
-From 1286400ffcc593b3917ab6ddeda5cf0a08423b1f Mon Sep 17 00:00:00 2001
+From 1aa9222fb2ef70f8c86e926561b547d924453041 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:49:31 +0200
-Subject: [PATCH 012/303] Step 2.1: Use dynamic template instead of static
+Subject: [PATCH 012/356] Step 2.1: Use dynamic template instead of static
 
 ---
  client/main.html | 22 ++++++++--------------
@@ -450,10 +450,10 @@ index dd1ef68..7f8c6d9 100644
 2.5.0
 
 
-From 8f9d191d6fe362780d0dffd3ccfe1c18d4350029 Mon Sep 17 00:00:00 2001
+From 0c9a5e36562ca4cd97718f32bc7c693df29878f2 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:50:30 +0200
-Subject: [PATCH 013/303] Step 2.2: Add the parties controller
+Subject: [PATCH 013/356] Step 2.2: Add the parties controller
 
 ---
  client/main.js | 16 ++++++++++++++--
@@ -487,10 +487,10 @@ index 558ad57..abc441c 100644
 2.5.0
 
 
-From a43c6b874af1bb45b103f7c34451f260c8e32680 Mon Sep 17 00:00:00 2001
+From b04c41ea446e7f28a788618de309fde03babbf8d Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:51:13 +0200
-Subject: [PATCH 014/303] Step 2.3: Remove the DI manual decleration
+Subject: [PATCH 014/356] Step 2.3: Remove the DI manual decleration
 
 ---
  client/main.js | 6 ++++--
@@ -521,10 +521,10 @@ index abc441c..feb14f8 100644
 2.5.0
 
 
-From 1a83444bdbde2027d9c8df188aca5c89aba6f8cb Mon Sep 17 00:00:00 2001
+From 30cf6c597dd8eae8e1db6d0af5f6afc51be28cab Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:51:56 +0200
-Subject: [PATCH 015/303] Step 2.4: Add ng-strict-di directive to the app
+Subject: [PATCH 015/356] Step 2.4: Add ng-strict-di directive to the app
 
 ---
  client/index.html | 2 +-
@@ -543,10 +543,10 @@ index f6b9ac4..48c2d09 100644
 2.5.0
 
 
-From ed017d02fd1be6074192b57587114239e6556dae Mon Sep 17 00:00:00 2001
+From 5ff43afd217c889939ce2ea81cddcdd61f389bd8 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:56:08 +0200
-Subject: [PATCH 016/303] Step 3.1: Add the parties collection
+Subject: [PATCH 016/356] Step 3.1: Add the parties collection
 
 ---
  collections/parties.js | 1 +
@@ -564,10 +564,10 @@ index 0000000..f78fa2c
 2.5.0
 
 
-From fceaa387c3d27c92b06fa0fccbe9b231a0f50d38 Mon Sep 17 00:00:00 2001
+From 73c907b7a52cde8c2a4511e5ee72fe1232dafd39 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 09:56:46 +0200
-Subject: [PATCH 017/303] Step 3.2: Add the parties collection helper
+Subject: [PATCH 017/356] Step 3.2: Add the parties collection helper
 
 ---
  client/main.js | 17 ++++++-----------
@@ -603,10 +603,10 @@ index feb14f8..1b17ade 100644
 2.5.0
 
 
-From 42404fd5dd02a88ccbdce6a2359d14e5064f762c Mon Sep 17 00:00:00 2001
+From 2e9847816b99cfc2f995117a72ad8ff130a450d7 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:00:24 +0200
-Subject: [PATCH 018/303] Step 3.3: Add some data to the parties collection
+Subject: [PATCH 018/356] Step 3.3: Add some data to the parties collection
 
 ---
  server/startup.js | 18 ++++++++++++++++++
@@ -641,10 +641,10 @@ index 0000000..ad3fd85
 2.5.0
 
 
-From 429122579f023951369f214957496fa2104276b6 Mon Sep 17 00:00:00 2001
+From 1292041aed71221f443418225ca0626e2d611687 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:00:58 +0200
-Subject: [PATCH 019/303] Step 3.4: Change to use controllerAs syntax
+Subject: [PATCH 019/356] Step 3.4: Change to use controllerAs syntax
 
 ---
  client/main.html | 4 ++--
@@ -667,10 +667,10 @@ index 7f8c6d9..62eca58 100644
 2.5.0
 
 
-From 499f28cac9a85b53777acd4c1ae78bf33bd66155 Mon Sep 17 00:00:00 2001
+From 16165a4348e7dde4885da9e3b10a2ad70bfa6591 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:07:22 +0200
-Subject: [PATCH 020/303] Step 3.5: Change the parties controller to use
+Subject: [PATCH 020/356] Step 3.5: Change the parties controller to use
  $reactive and `this` instead of `$scope`
 
 ---
@@ -700,10 +700,10 @@ index 1b17ade..58efe3e 100644
 2.5.0
 
 
-From ac3a1ed3c1728bb8a3de255f36f7b88d1cd592e1 Mon Sep 17 00:00:00 2001
+From 3c36724925070883b302b73c0001ebe9b86acbc4 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:12:43 +0200
-Subject: [PATCH 021/303] Step 3.6: Refactor PartiesListCtrl to be a component
+Subject: [PATCH 021/356] Step 3.6: Refactor PartiesListCtrl to be a component
 
 ---
  client/main.js | 20 ++++++++++++--------
@@ -744,10 +744,10 @@ index 58efe3e..a898321 100644
 2.5.0
 
 
-From 2f71142a0c0afd4b756b037cb6601146f8b7b87c Mon Sep 17 00:00:00 2001
+From 31b8e6cf06dbc6bc6e810620a718af9daaf31075 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:13:37 +0200
-Subject: [PATCH 022/303] Step 3.7: Change usage from controllerAs to
+Subject: [PATCH 022/356] Step 3.7: Change usage from controllerAs to
  components code-style - view
 
 ---
@@ -767,10 +767,10 @@ index 48c2d09..84f0ef3 100644
 2.5.0
 
 
-From c408870c63055ed706f4a497bf52ada32f158bba Mon Sep 17 00:00:00 2001
+From 5eca431d6bd94bccbc8fff724fe013c4be64ceb7 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:14:22 +0200
-Subject: [PATCH 023/303] Step 3.8: Move the parties list to a different HTML
+Subject: [PATCH 023/356] Step 3.8: Move the parties list to a different HTML
  file
 
 ---
@@ -794,10 +794,10 @@ index 0000000..64ac441
 2.5.0
 
 
-From 81f509602e38b2ce46a03c04710f8668625f2892 Mon Sep 17 00:00:00 2001
+From e9b05e468ae17cdb51cda544b4734d7cac9a248a Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:25:52 +0200
-Subject: [PATCH 024/303] Step 3.9: Move PartiesList to imports
+Subject: [PATCH 024/356] Step 3.9: Move PartiesList to imports
 
 ---
  imports/ui/components/partiesList/partiesList.js | 27 ++++++++++++++++++++++++
@@ -841,10 +841,10 @@ index 0000000..a5a8a27
 2.5.0
 
 
-From f8f948a31ed6235591891a69e309a0df434a53dc Mon Sep 17 00:00:00 2001
+From 895aeb726cfaa1bbef90d7c015bf06c1ff0f726f Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:26:25 +0200
-Subject: [PATCH 025/303] Step 3.10: Move PartiesList view to imports
+Subject: [PATCH 025/356] Step 3.10: Move PartiesList view to imports
 
 ---
  imports/ui/components/partiesList/partiesList.html | 6 ++++++
@@ -867,10 +867,10 @@ index 0000000..64ac441
 2.5.0
 
 
-From 216ad8296b6e8e23e8681f7f5c4107b523d2afdd Mon Sep 17 00:00:00 2001
+From 7e1b7ae48aa225bf8a2fc664789abeb6d8798668 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:27:59 +0200
-Subject: [PATCH 026/303] Step 3.11: Use PartiesList from imports
+Subject: [PATCH 026/356] Step 3.11: Use PartiesList from imports
 
 ---
  client/main.js | 22 +++++-----------------
@@ -911,10 +911,10 @@ index a898321..d643c33 100644
 2.5.0
 
 
-From 38df50f3630cfb3e711062760526c3178cc4447c Mon Sep 17 00:00:00 2001
+From c6fbe249654979b574d79b0e9a99a778d4f8fe3f Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:28:46 +0200
-Subject: [PATCH 027/303] Step 3.12: Remove old partiesList.html
+Subject: [PATCH 027/356] Step 3.12: Remove old partiesList.html
 
 ---
  client/partiesList.html | 6 ------
@@ -937,10 +937,10 @@ index 64ac441..0000000
 2.5.0
 
 
-From a114cf88664fb61ceea57fad84699592ee58d950 Mon Sep 17 00:00:00 2001
+From 785fe816e756e338b604411509c7087208f167e7 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:29:23 +0200
-Subject: [PATCH 028/303] Step 3.13: Remove unused main.html
+Subject: [PATCH 028/356] Step 3.13: Remove unused main.html
 
 ---
  client/main.html | 8 --------
@@ -965,10 +965,10 @@ index 62eca58..0000000
 2.5.0
 
 
-From a6ccec247231761fa0c7d87b9f7bafcd60b73eb0 Mon Sep 17 00:00:00 2001
+From 4f78728cc8081552eed3f1161a2815ab4f944594 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:29:59 +0200
-Subject: [PATCH 029/303] Step 3.14: Import template
+Subject: [PATCH 029/356] Step 3.14: Import template
 
 ---
  imports/ui/components/partiesList/partiesList.js | 2 ++
@@ -991,10 +991,10 @@ index a5a8a27..2a87f91 100644
 2.5.0
 
 
-From 0e1b4db5c946c94b6b6c39a46d9e3b7515bfb550 Mon Sep 17 00:00:00 2001
+From d1c819f9a5249a66f6e111f80a9b26d70b7a36f4 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:31:27 +0200
-Subject: [PATCH 030/303] Step 3.15: Create view for Socially component
+Subject: [PATCH 030/356] Step 3.15: Create view for Socially component
 
 ---
  imports/ui/components/socially/socially.html | 1 +
@@ -1012,10 +1012,10 @@ index 0000000..5e9673b
 2.5.0
 
 
-From ca04f484e2d50a6fe65a7ae1232fe19673bddbd3 Mon Sep 17 00:00:00 2001
+From 289aa17b9edac6cece59febea1660e5966f537ec Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:32:56 +0200
-Subject: [PATCH 031/303] Step 3.16: Create Socially component
+Subject: [PATCH 031/356] Step 3.16: Create Socially component
 
 ---
  imports/ui/components/socially/socially.js | 19 +++++++++++++++++++
@@ -1051,10 +1051,10 @@ index 0000000..e436684
 2.5.0
 
 
-From c67aa4bef37d2e9ad3942cfec32addc08f19e61e Mon Sep 17 00:00:00 2001
+From 1456467911b270596a9abc00b589aa557e414e3c Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:33:26 +0200
-Subject: [PATCH 032/303] Step 3.17: Replace parties-list with socially
+Subject: [PATCH 032/356] Step 3.17: Replace parties-list with socially
 
 ---
  client/index.html | 2 +-
@@ -1073,10 +1073,10 @@ index 84f0ef3..e6d21ea 100644
 2.5.0
 
 
-From 1de40712624702a7155c785a686c37756584926f Mon Sep 17 00:00:00 2001
+From 4016e79d970179dd5c526a67822779f446a2a413 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:34:53 +0200
-Subject: [PATCH 033/303] Step 3.18: Import Socially in main.js
+Subject: [PATCH 033/356] Step 3.18: Import Socially in main.js
 
 ---
  client/main.js | 7 +------
@@ -1101,10 +1101,10 @@ index d643c33..212f992 100644
 2.5.0
 
 
-From 635a3820a8a89274c3128039be15545815f5dd33 Mon Sep 17 00:00:00 2001
+From 489a4de3d6b81d5f47bff7915565fefb6ec969dd Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:35:46 +0200
-Subject: [PATCH 034/303] Step 4.1: Create template for PartyAdd component
+Subject: [PATCH 034/356] Step 4.1: Create template for PartyAdd component
 
 ---
  imports/ui/components/partyAdd/partyAdd.html | 11 +++++++++++
@@ -1132,10 +1132,10 @@ index 0000000..a61cf04
 2.5.0
 
 
-From 0496d187f518daa7c5349e790f1fd8116d1c9850 Mon Sep 17 00:00:00 2001
+From 0c8847700596be0b59a141176419da8cbe7a6e9e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:36:39 +0200
-Subject: [PATCH 035/303] Step 4.2: Create PartyAdd component
+Subject: [PATCH 035/356] Step 4.2: Create PartyAdd component
 
 ---
  imports/ui/components/partyAdd/partyAdd.js | 17 +++++++++++++++++
@@ -1169,10 +1169,10 @@ index 0000000..440dec8
 2.5.0
 
 
-From b89a25eee701638c68c6fbd806bf8785446b2ca0 Mon Sep 17 00:00:00 2001
+From 14a32bd3e1dc36ee7ad13308edfa267d09a80e66 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:37:19 +0200
-Subject: [PATCH 036/303] Step 4.3: Implement PartyAdd to the view
+Subject: [PATCH 036/356] Step 4.3: Implement PartyAdd to the view
 
 ---
  imports/ui/components/partiesList/partiesList.html | 2 ++
@@ -1192,10 +1192,10 @@ index 64ac441..229908b 100644
 2.5.0
 
 
-From 2571c37a279e8be143984db3c91432433a31c1c1 Mon Sep 17 00:00:00 2001
+From e81d6c9ca481ce73c4ef1041d274993cabc29eca Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:42:22 +0200
-Subject: [PATCH 037/303] Step 4.4: Add PartyAdd to PartiesList
+Subject: [PATCH 037/356] Step 4.4: Add PartyAdd to PartiesList
 
 ---
  imports/ui/components/partiesList/partiesList.js | 4 +++-
@@ -1227,10 +1227,10 @@ index 2a87f91..e72d93e 100644
 2.5.0
 
 
-From f9520c9f6686e26a2794d078dcc877ae38fdbc81 Mon Sep 17 00:00:00 2001
+From c332f9a5010759f4e53237829ec12020e88a3fb0 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:43:11 +0200
-Subject: [PATCH 038/303] Step 4.5: Add ng-model to the form inputs
+Subject: [PATCH 038/356] Step 4.5: Add ng-model to the form inputs
 
 ---
  imports/ui/components/partyAdd/partyAdd.html | 4 ++--
@@ -1257,10 +1257,10 @@ index a61cf04..f035ecd 100644
 2.5.0
 
 
-From 99dc0cffb984e13d55d3e2d41e7ca990b3a3b066 Mon Sep 17 00:00:00 2001
+From 2648480ac8565bea56bb65e5785b4567d90e7397 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:46:01 +0200
-Subject: [PATCH 039/303] Step 4.6: Add submit method to the button
+Subject: [PATCH 039/356] Step 4.6: Add submit method to the button
 
 ---
  imports/ui/components/partyAdd/partyAdd.html | 2 +-
@@ -1281,10 +1281,10 @@ index f035ecd..3508bef 100644
 2.5.0
 
 
-From dfe9ed3c40e5306a5ee379262d21d5bef998230d Mon Sep 17 00:00:00 2001
+From 5a28b98914c9b74da007c4a7a02f2e45c9eb0d8e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:47:30 +0200
-Subject: [PATCH 040/303] Step 4.7: Add submit method
+Subject: [PATCH 040/356] Step 4.7: Add submit method
 
 ---
  imports/ui/components/partyAdd/partyAdd.js | 10 +++++++++-
@@ -1315,10 +1315,10 @@ index 440dec8..3ab5c47 100644
 2.5.0
 
 
-From ac152aea0a00e197cc5afba74779fea20a846ad6 Mon Sep 17 00:00:00 2001
+From b4c38203954f01afb9a1412d8781ef78f0ac425e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:52:00 +0200
-Subject: [PATCH 041/303] Step 4.8: Move Parties to imports
+Subject: [PATCH 041/356] Step 4.8: Move Parties to imports
 
 ---
  imports/api/parties.js | 3 +++
@@ -1338,10 +1338,10 @@ index 0000000..e308632
 2.5.0
 
 
-From eed13254a3bd016ed692713d8b511dee220c2e89 Mon Sep 17 00:00:00 2001
+From e932cb1378f47199d8362270f0c62815eeaeb651 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:52:33 +0200
-Subject: [PATCH 042/303] Step 4.9: Remove old collection
+Subject: [PATCH 042/356] Step 4.9: Remove old collection
 
 ---
  collections/parties.js | 1 -
@@ -1359,10 +1359,10 @@ index f78fa2c..0000000
 2.5.0
 
 
-From 9e5a6f1a688c0c67af90de40dcf69e35e6e1fb1b Mon Sep 17 00:00:00 2001
+From 5a995721feca246fc0c93652988517b7f03b7625 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:56:28 +0200
-Subject: [PATCH 043/303] Step 4.10: Import new module with Parties collection
+Subject: [PATCH 043/356] Step 4.10: Import new module with Parties collection
 
 ---
  server/startup.js | 3 +++
@@ -1383,10 +1383,10 @@ index ad3fd85..6ce39cd 100644
 2.5.0
 
 
-From 554846d166b807ebb2d4a168490e53f804c19283 Mon Sep 17 00:00:00 2001
+From 3cca1ba0d4032087b797bb7a2cfe62fc1f98d08c Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 10:57:41 +0200
-Subject: [PATCH 044/303] Step 4.11: Import new module with Parties to
+Subject: [PATCH 044/356] Step 4.11: Import new module with Parties to
  PartiesList
 
 ---
@@ -1409,10 +1409,10 @@ index e72d93e..eba585f 100644
 2.5.0
 
 
-From f087d2c2f9ec80330ff04584a81de536a709a131 Mon Sep 17 00:00:00 2001
+From 4fbf3e632c7ea7530dcd46c95244f09726e0c1b1 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:00:20 +0200
-Subject: [PATCH 045/303] Step 4.12: Insert new party
+Subject: [PATCH 045/356] Step 4.12: Insert new party
 
 ---
  imports/ui/components/partyAdd/partyAdd.js | 8 +++++++-
@@ -1448,10 +1448,10 @@ index 3ab5c47..f51f219 100644
 2.5.0
 
 
-From 78f7954e2b22c28abcc72d03e4981c89dbb513de Mon Sep 17 00:00:00 2001
+From 7d820c4f5da5c00344b609362da262f7ea99cab8 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:01:18 +0200
-Subject: [PATCH 046/303] Step 4.13: Create view for PartyRemove component
+Subject: [PATCH 046/356] Step 4.13: Create view for PartyRemove component
 
 ---
  imports/ui/components/partyRemove/partyRemove.html | 1 +
@@ -1469,10 +1469,10 @@ index 0000000..1295105
 2.5.0
 
 
-From 7896b96f4fe79243e162c144f6946ce298bc136c Mon Sep 17 00:00:00 2001
+From 8a5378f75638663753bed33d1ac66bb9f5ab2140 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:04:08 +0200
-Subject: [PATCH 047/303] Step 4.14: Create PartyRemove component
+Subject: [PATCH 047/356] Step 4.14: Create PartyRemove component
 
 ---
  imports/ui/components/partyRemove/partyRemove.js | 21 +++++++++++++++++++++
@@ -1510,10 +1510,10 @@ index 0000000..2689076
 2.5.0
 
 
-From 050a6d829de8f9f8dcb38acfefac6948eeeb4ed2 Mon Sep 17 00:00:00 2001
+From ee16ecb8e923d31cb4db57ab9132a51fa5adeb54 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:05:10 +0200
-Subject: [PATCH 048/303] Step 4.15: Add party binding
+Subject: [PATCH 048/356] Step 4.15: Add party binding
 
 ---
  imports/ui/components/partyRemove/partyRemove.js | 3 +++
@@ -1537,10 +1537,10 @@ index 2689076..50f5ca8 100644
 2.5.0
 
 
-From 4102f2462e6f19447a83bdb964d66ffbba39ba95 Mon Sep 17 00:00:00 2001
+From c00d0996ffa5e8ba8a1515f978af1f587a63ce9b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:06:30 +0200
-Subject: [PATCH 049/303] Step 4.16: Remove party from collection
+Subject: [PATCH 049/356] Step 4.16: Remove party from collection
 
 ---
  imports/ui/components/partyRemove/partyRemove.js | 5 ++++-
@@ -1569,10 +1569,10 @@ index 50f5ca8..14c5861 100644
 2.5.0
 
 
-From c82fdd95d9dd8e25aff056582b08c0d4eea61bfe Mon Sep 17 00:00:00 2001
+From 43f5d46cbc880dc5e7b230662682912ae9cf9c26 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:07:06 +0200
-Subject: [PATCH 050/303] Step 4.17: Add PartyRemove
+Subject: [PATCH 050/356] Step 4.17: Add PartyRemove
 
 ---
  imports/ui/components/partiesList/partiesList.js | 4 +++-
@@ -1604,10 +1604,10 @@ index eba585f..1218977 100644
 2.5.0
 
 
-From 8f8a504bc184e69be51c6af5cf46c7047ece5561 Mon Sep 17 00:00:00 2001
+From 3961cff0290d35e7412fb6f39b0a6331ac74e9c0 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:08:02 +0200
-Subject: [PATCH 051/303] Step 4.18: Implement component
+Subject: [PATCH 051/356] Step 4.18: Implement component
 
 ---
  imports/ui/components/partiesList/partiesList.html | 1 +
@@ -1628,10 +1628,10 @@ index 229908b..24dedb1 100644
 2.5.0
 
 
-From 1820d9bfdaaa3d4c4f3ff638bf6262deb6d13ed3 Mon Sep 17 00:00:00 2001
+From 86d54f7c818ec55e438fbc4ecd5ef6edf9b59942 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 14:21:49 +0200
-Subject: [PATCH 052/303] Step 4.19: Add `sanjo:jasmine` and reporters
+Subject: [PATCH 052/356] Step 4.19: Add `sanjo:jasmine` and reporters
 
 ---
  .meteor/packages | 3 +++
@@ -1650,57 +1650,57 @@ index d74ee49..03a4feb 100644
 +velocity:html-reporter
 +velocity:console-reporter
 diff --git a/.meteor/versions b/.meteor/versions
-index a82d518..9f4aab2 100644
+index 5a2d576..550c9b0 100644
 --- a/.meteor/versions
 +++ b/.meteor/versions
 @@ -1,4 +1,5 @@
- allow-deny@1.0.2
+ allow-deny@1.0.4
 +amplify@1.0.0
  angular-templates@1.0.2
- autopublish@1.0.5
- autoupdate@1.2.6
-@@ -33,6 +34,7 @@ id-map@1.0.5
- insecure@1.0.5
- jquery@1.11.6
- launch-screen@1.0.8
+ autopublish@1.0.7
+ autoupdate@1.2.8
+@@ -33,6 +34,7 @@ id-map@1.0.7
+ insecure@1.0.7
+ jquery@1.11.8
+ launch-screen@1.0.11
 +less@2.5.6
- livedata@1.0.16
- logging@1.0.10
- meteor@1.1.12
-@@ -52,18 +54,25 @@ ordered-dict@1.0.5
+ livedata@1.0.18
+ logging@1.0.12
+ meteor@1.1.14
+@@ -52,18 +54,25 @@ ordered-dict@1.0.7
  pbastowski:angular-babel@1.3.2
- promise@0.6.5
- random@1.0.7
+ promise@0.6.7
+ random@1.0.9
 +reactive-dict@1.1.5
- reactive-var@1.0.7
- reload@1.1.6
- retry@1.0.5
- routepolicy@1.0.8
-+sanjo:jasmine@1.0.0
+ reactive-var@1.0.9
+ reload@1.1.8
+ retry@1.0.7
+ routepolicy@1.0.10
++sanjo:jasmine@1.0.1
 +session@1.1.3
- spacebars@1.0.9
- spacebars-compiler@1.0.9
- standard-minifier-css@1.0.4
- standard-minifier-js@1.0.4
+ spacebars@1.0.11
+ spacebars-compiler@1.0.11
+ standard-minifier-css@1.0.6
+ standard-minifier-js@1.0.6
 +templating@1.1.7
  templating-tools@1.0.2
- tracker@1.0.11
- ui@1.0.9
- underscore@1.0.6
- url@1.0.7
+ tracker@1.0.13
+ ui@1.0.11
+ underscore@1.0.8
+ url@1.0.9
 +velocity:console-reporter@0.2.1
 +velocity:html-reporter@0.10.0
 +velocity:reports@1.0.0
- webapp@1.2.6
- webapp-hashing@1.0.7
+ webapp@1.2.8
+ webapp-hashing@1.0.9
 -- 
 2.5.0
 
 
-From 1f950fb44783d4c0e8b2ebfb49eb4de0725a9267 Mon Sep 17 00:00:00 2001
+From fb4e0344125b5354e6b904a0a2ecdb9e413f4346 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 14:23:16 +0200
-Subject: [PATCH 053/303] Step 4.20: Add `test:watch` npm script
+Subject: [PATCH 053/356] Step 4.20: Add `test:watch` npm script
 
 ---
  package.json | 3 ++-
@@ -1724,10 +1724,10 @@ index 1fdb919..af9f43d 100644
 2.5.0
 
 
-From 7c1a335abb70fd7cad63760aa386a2098718cfd1 Mon Sep 17 00:00:00 2001
+From bb1e6d50727756e1435e36d4c629b3c0265caf19 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 14:24:39 +0200
-Subject: [PATCH 054/303] Step 4.21: Install `angular-mocks`
+Subject: [PATCH 054/356] Step 4.21: Install `angular-mocks`
 
 ---
  package.json | 3 +++
@@ -1750,10 +1750,10 @@ index af9f43d..1555b86 100644
 2.5.0
 
 
-From 2f3e0fe98b516be318a0f78c1455df701e871e1f Mon Sep 17 00:00:00 2001
+From fff5bb0ed5cbefac4ba669484a32424ce5266027 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 14:45:42 +0200
-Subject: [PATCH 055/303] Step 4.22: Tests of PartyAdd
+Subject: [PATCH 055/356] Step 4.22: Tests of PartyAdd
 
 ---
  .../components/partyAdd/client/partyAdd.tests.js   | 53 ++++++++++++++++++++++
@@ -1823,10 +1823,10 @@ index 0000000..cc1d35e
 2.5.0
 
 
-From 562d09f43a183e0427a22ebcb8b7657f3449cb31 Mon Sep 17 00:00:00 2001
+From d73405d2705d9f99c4a9381e79763263f53cf7e3 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 14:50:11 +0200
-Subject: [PATCH 056/303] Step 4.23: Tests of PartyRemove
+Subject: [PATCH 056/356] Step 4.23: Tests of PartyRemove
 
 ---
  .../partyRemove/client/partyRemove.tests.js        | 37 ++++++++++++++++++++++
@@ -1880,10 +1880,10 @@ index 0000000..e8b6e97
 2.5.0
 
 
-From bc8938c56066f39f313669ec0681e095108c4cca Mon Sep 17 00:00:00 2001
+From aecd2d3c772053c96f55fb0dd82af9dba7af3576 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:09:16 +0200
-Subject: [PATCH 057/303] Step 5.1: Add ui-router
+Subject: [PATCH 057/356] Step 5.1: Add ui-router
 
 ---
  package.json | 1 +
@@ -1905,10 +1905,10 @@ index 1555b86..a9636f0 100644
 2.5.0
 
 
-From cafe8d650a5cab00d8cb7682e5a03af10330f2f1 Mon Sep 17 00:00:00 2001
+From 961576d296c0cdc1c7d2188b91f235cb9bfa7c45 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:10:34 +0200
-Subject: [PATCH 058/303] Step 5.2: Add uiRouter to Socially
+Subject: [PATCH 058/356] Step 5.2: Add uiRouter to Socially
 
 ---
  imports/ui/components/socially/socially.js | 2 ++
@@ -1937,10 +1937,10 @@ index e436684..3de6e3c 100644
 2.5.0
 
 
-From 7689552aa55584daf31edd97986230a3853f2194 Mon Sep 17 00:00:00 2001
+From 09bc4c3c116c556480cca3a6f687ff6a97e7d4e1 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:11:08 +0200
-Subject: [PATCH 059/303] Step 5.3: Add base tag to main template
+Subject: [PATCH 059/356] Step 5.3: Add base tag to main template
 
 ---
  client/index.html | 3 +++
@@ -1961,10 +1961,10 @@ index e6d21ea..806f6ab 100644
 2.5.0
 
 
-From 39be2f78a1073884ea82cf9c91b6437fd3e61fc8 Mon Sep 17 00:00:00 2001
+From b665e002e8a2c14af0d5220f38bf62c425861e0e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:11:52 +0200
-Subject: [PATCH 060/303] Step 5.4: Add uiView to Socially view
+Subject: [PATCH 060/356] Step 5.4: Add uiView to Socially view
 
 ---
  imports/ui/components/socially/socially.html | 2 +-
@@ -1981,10 +1981,10 @@ index 5e9673b..19b303a 100644
 2.5.0
 
 
-From b811ea90443d3a593e8df41ea70a5e2aec3f1a9a Mon Sep 17 00:00:00 2001
+From ebce629fde38d66701dfe3a0b47b11c402e53ca5 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:13:54 +0200
-Subject: [PATCH 061/303] Step 5.5: Define `parties` route
+Subject: [PATCH 061/356] Step 5.5: Define `parties` route
 
 ---
  imports/ui/components/partiesList/partiesList.js | 14 +++++++++++++-
@@ -2028,10 +2028,10 @@ index 1218977..bc00317 100644
 2.5.0
 
 
-From 00bb57640c7d69b271a106472177dfc431493aee Mon Sep 17 00:00:00 2001
+From 1ee2bc95b6e9a0b6e38545a247fcc6a3ac55e0f1 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:15:19 +0200
-Subject: [PATCH 062/303] Step 5.6: Set html5Mode and `parties` as default
+Subject: [PATCH 062/356] Step 5.6: Set html5Mode and `parties` as default
  route
 
 ---
@@ -2061,10 +2061,10 @@ index 3de6e3c..f902505 100644
 2.5.0
 
 
-From 9a333ef9d8441f8a0179637cb0baf164c47881ba Mon Sep 17 00:00:00 2001
+From 0d66c71a37bb8df53d4801844dfa4b8adb901e3e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:16:09 +0200
-Subject: [PATCH 063/303] Step 5.7: Create view for Navigation component
+Subject: [PATCH 063/356] Step 5.7: Create view for Navigation component
 
 ---
  imports/ui/components/navigation/navigation.html | 3 +++
@@ -2084,10 +2084,10 @@ index 0000000..def2640
 2.5.0
 
 
-From 42868375857918acdb9d78bd142c4b421584d057 Mon Sep 17 00:00:00 2001
+From e921a09ffea73dd0a25780c8c0a486d9b3b7c38c Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:17:01 +0200
-Subject: [PATCH 064/303] Step 5.8: Create Navigation component
+Subject: [PATCH 064/356] Step 5.8: Create Navigation component
 
 ---
  imports/ui/components/navigation/navigation.js | 14 ++++++++++++++
@@ -2118,10 +2118,10 @@ index 0000000..a79d5ec
 2.5.0
 
 
-From f332f3cd080fe47f5faa532efb7ad81c51d1aaa8 Mon Sep 17 00:00:00 2001
+From ee73bfbacdba3c08ccaee5235dfd431a225fb2b9 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:17:37 +0200
-Subject: [PATCH 065/303] Step 5.9: Implement Navigation in the view
+Subject: [PATCH 065/356] Step 5.9: Implement Navigation in the view
 
 ---
  imports/ui/components/socially/socially.html | 2 ++
@@ -2139,10 +2139,10 @@ index 19b303a..7fdb2de 100644
 2.5.0
 
 
-From b98f3b64a8fb8e1a32ea2885718bb1f26bc8b8e6 Mon Sep 17 00:00:00 2001
+From 92d5f9b957bc566406ae3377eb99796c1e46d16e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:18:12 +0200
-Subject: [PATCH 066/303] Step 5.10: Add Navigation to Socially
+Subject: [PATCH 066/356] Step 5.10: Add Navigation to Socially
 
 ---
  imports/ui/components/socially/socially.js | 4 +++-
@@ -2174,10 +2174,10 @@ index f902505..7ef0d74 100644
 2.5.0
 
 
-From 4a2468187ae4de03e181fa4e7bb64ccda7463aa4 Mon Sep 17 00:00:00 2001
+From 138c128bff97b2c06649e1ec62a94797d6b73e4d Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:19:42 +0200
-Subject: [PATCH 067/303] Step 5.11: Create view for the PartyDetails
+Subject: [PATCH 067/356] Step 5.11: Create view for the PartyDetails
 
 ---
  imports/ui/components/partyDetails/partyDetails.html | 1 +
@@ -2195,10 +2195,10 @@ index 0000000..3ea8425
 2.5.0
 
 
-From 75e36b1ce874b8662f6d1dc43cb2276bceea5071 Mon Sep 17 00:00:00 2001
+From aec5145ffbc851382147151936a033d23ed1cb34 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:21:42 +0200
-Subject: [PATCH 068/303] Step 5.12: Create PartyDetails
+Subject: [PATCH 068/356] Step 5.12: Create PartyDetails
 
 ---
  imports/ui/components/partyDetails/partyDetails.js | 24 ++++++++++++++++++++++
@@ -2239,10 +2239,10 @@ index 0000000..555c7c6
 2.5.0
 
 
-From 26ecd002fcfd1c33da6f095f46f2028614696b3c Mon Sep 17 00:00:00 2001
+From 55193518848ed72be320b674e9e3ee21f57ccd3a Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:22:56 +0200
-Subject: [PATCH 069/303] Step 5.13: Set partyDetails state
+Subject: [PATCH 069/356] Step 5.13: Set partyDetails state
 
 ---
  imports/ui/components/partyDetails/partyDetails.js | 17 ++++++++++++++---
@@ -2288,10 +2288,10 @@ index 555c7c6..41dfe6b 100644
 2.5.0
 
 
-From 884d96c3aaa2e8f0f23d02a2973184c95ab0654c Mon Sep 17 00:00:00 2001
+From 178576b15c3447772887c73d55fec3fd0822f558 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:23:41 +0200
-Subject: [PATCH 070/303] Step 5.14: Add PartyDetails to Socially
+Subject: [PATCH 070/356] Step 5.14: Add PartyDetails to Socially
 
 ---
  imports/ui/components/socially/socially.js | 2 ++
@@ -2321,10 +2321,10 @@ index 7ef0d74..2a2c103 100644
 2.5.0
 
 
-From 664825da8b1cc171b1690992e47e2f4d25cc653a Mon Sep 17 00:00:00 2001
+From cd730ac469a04166292b283978b741c12f4e068e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:25:15 +0200
-Subject: [PATCH 071/303] Step 5.15: Add link
+Subject: [PATCH 071/356] Step 5.15: Add link
 
 ---
  imports/ui/components/partiesList/partiesList.html | 4 +++-
@@ -2349,10 +2349,10 @@ index 24dedb1..c1b07e2 100644
 2.5.0
 
 
-From 980c0025d8ae557874341937350a6034755fa4b7 Mon Sep 17 00:00:00 2001
+From 234cd7772c7ed7615ca769b6eeb9c884c1b2dcd9 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:30:15 +0200
-Subject: [PATCH 072/303] Step 6.1: Add party helper
+Subject: [PATCH 072/356] Step 6.1: Add party helper
 
 ---
  imports/ui/components/partyDetails/partyDetails.js | 13 ++++++++++++-
@@ -2391,10 +2391,10 @@ index 41dfe6b..75ad55a 100644
 2.5.0
 
 
-From 8d1fa2d0bc3aabfd0a77e3a8fa14e77926963da4 Mon Sep 17 00:00:00 2001
+From 27c61841593947bd71ea81dac725a552ac122ede Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:33:34 +0200
-Subject: [PATCH 073/303] Step 6.2: Add form with the party details to the
+Subject: [PATCH 073/356] Step 6.2: Add form with the party details to the
  party details page
 
 ---
@@ -2416,10 +2416,10 @@ index 3ea8425..8c1201f 100644
 2.5.0
 
 
-From 6fde87ef3b6416660ec3ad04bf0af47bbec5a313 Mon Sep 17 00:00:00 2001
+From ded721bbf151955392f3257154ff21d6472a1850 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:34:10 +0200
-Subject: [PATCH 074/303] Step 6.3: Add save and back buttons to the view
+Subject: [PATCH 074/356] Step 6.3: Add save and back buttons to the view
 
 ---
  imports/ui/components/partyDetails/partyDetails.html | 3 +++
@@ -2441,10 +2441,10 @@ index 8c1201f..b5c939b 100644
 2.5.0
 
 
-From 04dbcb764e1009a4fe023e3657d04508fc5a8593 Mon Sep 17 00:00:00 2001
+From 655d500f4fcc6b24f1225ddaf16b0390f7ddddc0 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:35:38 +0200
-Subject: [PATCH 075/303] Step 6.4: Implement save button on the component
+Subject: [PATCH 075/356] Step 6.4: Implement save button on the component
  logic
 
 ---
@@ -2477,10 +2477,10 @@ index 75ad55a..9e5092e 100644
 2.5.0
 
 
-From 826b42bc5f91bd0c33643daa442b87e320c23169 Mon Sep 17 00:00:00 2001
+From a7a40c6b8ddc83950e290fc5a89af1332326fd4b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:36:24 +0200
-Subject: [PATCH 076/303] Step 6.5: Handle success and fail for data actions
+Subject: [PATCH 076/356] Step 6.5: Handle success and fail for data actions
 
 ---
  imports/ui/components/partyDetails/partyDetails.js | 6 ++++++
@@ -2507,10 +2507,10 @@ index 9e5092e..0916e06 100644
 2.5.0
 
 
-From 09a43208ff2624ed81294678539d15944543732c Mon Sep 17 00:00:00 2001
+From da1b2c05bb5b3ea91d65270a3b8c81acb7c20d52 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 15:11:57 +0200
-Subject: [PATCH 077/303] Step 6.6: Tests of PartyDetails
+Subject: [PATCH 077/356] Step 6.6: Tests of PartyDetails
 
 ---
  .../partyDetails/client/partyDetails.tests.js      | 49 ++++++++++++++++++++++
@@ -2576,10 +2576,10 @@ index 0000000..997304e
 2.5.0
 
 
-From 5d9cf87da3d197dcbb3d61d634dee0fef17ca7d8 Mon Sep 17 00:00:00 2001
+From 127e682f06684c410a87c106011396877ca1216d Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:38:12 +0200
-Subject: [PATCH 078/303] Step 7.1: Move startup to imports
+Subject: [PATCH 078/356] Step 7.1: Move startup to imports
 
 ---
  imports/startup/fixtures.js | 21 +++++++++++++++++++++
@@ -2617,10 +2617,10 @@ index 0000000..d92fb48
 2.5.0
 
 
-From 5404e8ef54f9721e038e5a943168b6f8cfe84ca9 Mon Sep 17 00:00:00 2001
+From 73d9c50b726ebe86c2210743944f5f3a016fd1db Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:39:27 +0200
-Subject: [PATCH 079/303] Step 7.2: Create main entry point on server-side
+Subject: [PATCH 079/356] Step 7.2: Create main entry point on server-side
 
 ---
  server/main.js | 1 +
@@ -2638,10 +2638,10 @@ index 0000000..40efcd1
 2.5.0
 
 
-From 8cdb757897f088b77c1c1876e87cc33e8546bbc7 Mon Sep 17 00:00:00 2001
+From 6dd3babaef4705497a7f7e6fefbf493c52e38f2e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:40:16 +0200
-Subject: [PATCH 080/303] Step 7.3: Import Parties on server-side to be
+Subject: [PATCH 080/356] Step 7.3: Import Parties on server-side to be
  synchronized
 
 ---
@@ -2659,10 +2659,10 @@ index 40efcd1..d4c97f0 100644
 2.5.0
 
 
-From 8400bc416693ae747222c6367f61652fabfd4645 Mon Sep 17 00:00:00 2001
+From a814d40e10909b1c91b7c1c656a7f9887bbe5ed5 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:40:34 +0200
-Subject: [PATCH 081/303] Step 7.4: Remove old startup.js
+Subject: [PATCH 081/356] Step 7.4: Remove old startup.js
 
 ---
  server/startup.js | 21 ---------------------
@@ -2700,10 +2700,10 @@ index 6ce39cd..0000000
 2.5.0
 
 
-From 11644be5ac4a3ceb9cec2529b63cafe2941dfacc Mon Sep 17 00:00:00 2001
+From a3411d6ff9c22a7650c5e916867ce0c03c818b07 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:41:57 +0200
-Subject: [PATCH 082/303] Step 8.1: Remove `insecure` package
+Subject: [PATCH 082/356] Step 8.1: Remove `insecure` package
 
 ---
  .meteor/packages | 1 -
@@ -2723,25 +2723,25 @@ index 03a4feb..7368104 100644
  angular-templates
  sanjo:jasmine
 diff --git a/.meteor/versions b/.meteor/versions
-index 9f4aab2..dc09abe 100644
+index 550c9b0..34d1d93 100644
 --- a/.meteor/versions
 +++ b/.meteor/versions
-@@ -31,7 +31,6 @@ html-tools@1.0.7
- htmljs@1.0.7
- http@1.1.3
- id-map@1.0.5
--insecure@1.0.5
- jquery@1.11.6
- launch-screen@1.0.8
+@@ -31,7 +31,6 @@ html-tools@1.0.9
+ htmljs@1.0.9
+ http@1.1.5
+ id-map@1.0.7
+-insecure@1.0.7
+ jquery@1.11.8
+ launch-screen@1.0.11
  less@2.5.6
 -- 
 2.5.0
 
 
-From cdcd13b3f272586c4b24e0197a6e1ed13ed45b6a Mon Sep 17 00:00:00 2001
+From ccc2ca610aa13f793049fc7bdbbd80c366b63162 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:42:53 +0200
-Subject: [PATCH 083/303] Step 8.2: Add `accounts-password`
+Subject: [PATCH 083/356] Step 8.2: Add `accounts-password`
 
 ---
  .meteor/packages |  1 +
@@ -2758,73 +2758,73 @@ index 7368104..f402f80 100644
  velocity:console-reporter
 +accounts-password
 diff --git a/.meteor/versions b/.meteor/versions
-index dc09abe..5d9416a 100644
+index 34d1d93..87daa22 100644
 --- a/.meteor/versions
 +++ b/.meteor/versions
 @@ -1,3 +1,5 @@
 +accounts-base@1.2.4
 +accounts-password@1.1.6
- allow-deny@1.0.2
+ allow-deny@1.0.4
  amplify@1.0.0
  angular-templates@1.0.2
-@@ -17,12 +19,14 @@ check@1.1.2
- ddp@1.2.3
- ddp-client@1.2.3
- ddp-common@1.2.3
+@@ -17,12 +19,14 @@ check@1.2.1
+ ddp@1.2.5
+ ddp-client@1.2.5
+ ddp-common@1.2.5
 +ddp-rate-limiter@1.0.2
- ddp-server@1.2.4
- deps@1.0.10
- diff-sequence@1.0.3
- ecmascript@0.4.1
- ecmascript-runtime@0.2.8
- ejson@1.0.9
+ ddp-server@1.2.6
+ deps@1.0.12
+ diff-sequence@1.0.5
+ ecmascript@0.4.3
+ ecmascript-runtime@0.2.10
+ ejson@1.0.11
 +email@1.0.10
- es5-shim@4.5.8
- fastclick@1.0.9
- geojson-utils@1.0.6
-@@ -35,6 +39,7 @@ jquery@1.11.6
- launch-screen@1.0.8
+ es5-shim@4.5.10
+ fastclick@1.0.11
+ geojson-utils@1.0.8
+@@ -35,6 +39,7 @@ jquery@1.11.8
+ launch-screen@1.0.11
  less@2.5.6
- livedata@1.0.16
+ livedata@1.0.18
 +localstorage@1.0.7
- logging@1.0.10
- meteor@1.1.12
- meteor-base@1.0.2
-@@ -47,6 +52,7 @@ modules@0.5.1
- modules-runtime@0.6.1
- mongo@1.1.5
- mongo-id@1.0.2
+ logging@1.0.12
+ meteor@1.1.14
+ meteor-base@1.0.4
+@@ -47,6 +52,7 @@ modules@0.6.1
+ modules-runtime@0.6.3
+ mongo@1.1.7
+ mongo-id@1.0.4
 +npm-bcrypt@0.7.8_2
- npm-mongo@1.4.41
- observe-sequence@1.0.9
- ordered-dict@1.0.5
+ npm-mongo@1.4.43
+ observe-sequence@1.0.11
+ ordered-dict@1.0.7
 @@ -54,14 +60,18 @@ pbastowski:angular-babel@1.3.2
- promise@0.6.5
- random@1.0.7
+ promise@0.6.7
+ random@1.0.9
  reactive-dict@1.1.5
 +rate-limit@1.0.2
- reactive-var@1.0.7
- reload@1.1.6
- retry@1.0.5
- routepolicy@1.0.8
- sanjo:jasmine@1.0.0
+ reactive-var@1.0.9
+ reload@1.1.8
+ retry@1.0.7
+ routepolicy@1.0.10
+ sanjo:jasmine@1.0.1
  session@1.1.3
 +service-configuration@1.0.7
 +sha@1.0.5
- spacebars@1.0.9
- spacebars-compiler@1.0.9
+ spacebars@1.0.11
+ spacebars-compiler@1.0.11
 +srp@1.0.6
- standard-minifier-css@1.0.4
- standard-minifier-js@1.0.4
+ standard-minifier-css@1.0.6
+ standard-minifier-js@1.0.6
  templating@1.1.7
 -- 
 2.5.0
 
 
-From aea175bf7c1e73f1662fb6f0156c8b34a645801f Mon Sep 17 00:00:00 2001
+From d41937bb8b44b066239e4d97afa5ebb8c57df365 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:44:10 +0200
-Subject: [PATCH 084/303] Step 8.3: Add `dotansimha:accounts-ui-angular`
+Subject: [PATCH 084/356] Step 8.3: Add `dotansimha:accounts-ui-angular`
 
 ---
  .meteor/packages | 1 +
@@ -2841,7 +2841,7 @@ index f402f80..cc4586d 100644
  accounts-password
 +dotansimha:accounts-ui-angular
 diff --git a/.meteor/versions b/.meteor/versions
-index 5d9416a..f4511e6 100644
+index 87daa22..f995f1b 100644
 --- a/.meteor/versions
 +++ b/.meteor/versions
 @@ -1,5 +1,7 @@
@@ -2849,57 +2849,57 @@ index 5d9416a..f4511e6 100644
  accounts-password@1.1.6
 +accounts-ui@1.1.7
 +accounts-ui-unstyled@1.1.10
- allow-deny@1.0.2
+ allow-deny@1.0.4
  amplify@1.0.0
  angular-templates@1.0.2
-@@ -10,6 +12,7 @@ babel-runtime@0.1.6
- base64@1.0.6
- binary-heap@1.0.6
- blaze@2.1.5
+@@ -10,6 +12,7 @@ babel-runtime@0.1.8
+ base64@1.0.8
+ binary-heap@1.0.8
+ blaze@2.1.7
 +blaze-html-templates@1.0.2
- blaze-tools@1.0.6
- boilerplate-generator@1.0.6
+ blaze-tools@1.0.8
+ boilerplate-generator@1.0.8
  caching-compiler@1.0.2
 @@ -23,6 +26,7 @@ ddp-rate-limiter@1.0.2
- ddp-server@1.2.4
- deps@1.0.10
- diff-sequence@1.0.3
+ ddp-server@1.2.6
+ deps@1.0.12
+ diff-sequence@1.0.5
 +dotansimha:accounts-ui-angular@0.0.4
- ecmascript@0.4.1
- ecmascript-runtime@0.2.8
- ejson@1.0.9
-@@ -61,6 +65,7 @@ promise@0.6.5
- random@1.0.7
+ ecmascript@0.4.3
+ ecmascript-runtime@0.2.10
+ ejson@1.0.11
+@@ -61,6 +65,7 @@ promise@0.6.7
+ random@1.0.9
  reactive-dict@1.1.5
  rate-limit@1.0.2
 +reactive-dict@1.1.5
- reactive-var@1.0.7
- reload@1.1.6
- retry@1.0.5
-@@ -68,6 +73,7 @@ routepolicy@1.0.8
- sanjo:jasmine@1.0.0
+ reactive-var@1.0.9
+ reload@1.1.8
+ retry@1.0.7
+@@ -68,6 +73,7 @@ routepolicy@1.0.10
+ sanjo:jasmine@1.0.1
  session@1.1.3
  service-configuration@1.0.7
 +session@1.1.3
  sha@1.0.5
- spacebars@1.0.9
- spacebars-compiler@1.0.9
-@@ -76,6 +82,7 @@ standard-minifier-css@1.0.4
- standard-minifier-js@1.0.4
+ spacebars@1.0.11
+ spacebars-compiler@1.0.11
+@@ -76,6 +82,7 @@ standard-minifier-css@1.0.6
+ standard-minifier-js@1.0.6
  templating@1.1.7
  templating-tools@1.0.2
 +tmeasday:check-npm-versions@0.1.1
- tracker@1.0.11
- ui@1.0.9
- underscore@1.0.6
+ tracker@1.0.13
+ ui@1.0.11
+ underscore@1.0.8
 -- 
 2.5.0
 
 
-From 5443b3f8f8baf805f0c899c8798091cbd107ab51 Mon Sep 17 00:00:00 2001
+From bda3c2aa4bbe28cfcc91deff8be6e8db2c34515f Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:44:45 +0200
-Subject: [PATCH 085/303] Step 8.4: Add a dependecy for accounts-ui package
+Subject: [PATCH 085/356] Step 8.4: Add a dependecy for accounts-ui package
 
 ---
  imports/ui/components/socially/socially.js | 3 ++-
@@ -2923,10 +2923,10 @@ index 2a2c103..2cc775f 100644
 2.5.0
 
 
-From 94f79f1c6ca2d71f073c979601bb2a71e18f1be1 Mon Sep 17 00:00:00 2001
+From 6adbd153b4ae38b800dd9cbf7a10e8dd1861fb24 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 11:45:52 +0200
-Subject: [PATCH 086/303] Step 8.5: Add usage for login-buttons directive
+Subject: [PATCH 086/356] Step 8.5: Add usage for login-buttons directive
 
 ---
  imports/ui/components/socially/socially.html | 2 ++
@@ -2946,10 +2946,10 @@ index 7fdb2de..83c40e7 100644
 2.5.0
 
 
-From 35e5c594ee2f569a3886d4f67cfe74353ac5450a Mon Sep 17 00:00:00 2001
+From 9bd4c79a114e18fcf683a04a216d575f50b0c369 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:01:43 +0200
-Subject: [PATCH 087/303] Step 8.6: Add allow logic to the model
+Subject: [PATCH 087/356] Step 8.6: Add allow logic to the model
 
 ---
  imports/api/parties.js | 12 ++++++++++++
@@ -2979,10 +2979,10 @@ index e308632..3e283c1 100644
 2.5.0
 
 
-From 8bf25065247c492fbd77e9cfdc7a2f0032e741e1 Mon Sep 17 00:00:00 2001
+From 97650c17b5184f124b75a5b148dd71f841ca74ec Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:02:37 +0200
-Subject: [PATCH 088/303] Step 8.7: Add current user to the new party
+Subject: [PATCH 088/356] Step 8.7: Add current user to the new party
 
 ---
  imports/ui/components/partyAdd/partyAdd.js | 3 +++
@@ -3013,10 +3013,10 @@ index f51f219..5b1ead3 100644
 2.5.0
 
 
-From 85078080e84c8099a85614f46e13ae09b2f2e3bf Mon Sep 17 00:00:00 2001
+From 392650d94b84f56535fcf372aaf440ca8175c60e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:03:33 +0200
-Subject: [PATCH 089/303] Step 8.8: Add facebook and twitter
+Subject: [PATCH 089/356] Step 8.8: Add facebook and twitter
 
 ---
  .meteor/packages | 2 ++
@@ -3034,7 +3034,7 @@ index cc4586d..0af80ec 100644
 +accounts-facebook
 +accounts-twitter
 diff --git a/.meteor/versions b/.meteor/versions
-index f4511e6..39637f1 100644
+index f995f1b..feb6048 100644
 --- a/.meteor/versions
 +++ b/.meteor/versions
 @@ -1,5 +1,8 @@
@@ -3045,41 +3045,41 @@ index f4511e6..39637f1 100644
 +accounts-twitter@1.0.7
  accounts-ui@1.1.7
  accounts-ui-unstyled@1.1.10
- allow-deny@1.0.2
-@@ -32,6 +35,7 @@ ecmascript-runtime@0.2.8
- ejson@1.0.9
+ allow-deny@1.0.4
+@@ -32,6 +35,7 @@ ecmascript-runtime@0.2.10
+ ejson@1.0.11
  email@1.0.10
- es5-shim@4.5.8
+ es5-shim@4.5.10
 +facebook@1.2.4
- fastclick@1.0.9
- geojson-utils@1.0.6
- hot-code-push@1.0.2
-@@ -58,6 +62,9 @@ mongo@1.1.5
- mongo-id@1.0.2
+ fastclick@1.0.11
+ geojson-utils@1.0.8
+ hot-code-push@1.0.4
+@@ -58,6 +62,9 @@ mongo@1.1.7
+ mongo-id@1.0.4
  npm-bcrypt@0.7.8_2
- npm-mongo@1.4.41
+ npm-mongo@1.4.43
 +oauth@1.1.8
 +oauth1@1.1.7
 +oauth2@1.1.7
- observe-sequence@1.0.9
- ordered-dict@1.0.5
+ observe-sequence@1.0.11
+ ordered-dict@1.0.7
  pbastowski:angular-babel@1.3.2
 @@ -84,6 +91,7 @@ templating@1.1.7
  templating-tools@1.0.2
  tmeasday:check-npm-versions@0.1.1
- tracker@1.0.11
+ tracker@1.0.13
 +twitter@1.1.7
- ui@1.0.9
- underscore@1.0.6
- url@1.0.7
+ ui@1.0.11
+ underscore@1.0.8
+ url@1.0.9
 -- 
 2.5.0
 
 
-From 7e27b2a8d6972971533091d5ba9ad9d9c353ddeb Mon Sep 17 00:00:00 2001
+From 9f243ab1939a0fb06152d3c927e231ce2400f93e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:05:29 +0200
-Subject: [PATCH 090/303] Step 8.9: Add permissions limit to the party details
+Subject: [PATCH 090/356] Step 8.9: Add permissions limit to the party details
  page
 
 ---
@@ -3120,10 +3120,10 @@ index 0916e06..bd71782 100644
 2.5.0
 
 
-From 596f62df54c629260c7c8b3ccef95ca8eac1d41a Mon Sep 17 00:00:00 2001
+From 26735580ca0f7eb842f965cbc3962766cebdc4ed Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:05:59 +0200
-Subject: [PATCH 091/303] Step 8.10: Add the reason of rejection
+Subject: [PATCH 091/356] Step 8.10: Add the reason of rejection
 
 ---
  imports/ui/components/partyDetails/partyDetails.js | 2 +-
@@ -3146,10 +3146,10 @@ index bd71782..12c05aa 100644
 2.5.0
 
 
-From 45572be984a55dd2f8410d7c57e388a0a77ce4c9 Mon Sep 17 00:00:00 2001
+From 8fae7a42ceccd8aa9ad05536d471b7657929e59c Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:07:34 +0200
-Subject: [PATCH 092/303] Step 8.11: Handle `AUTH_REQUIRED`
+Subject: [PATCH 092/356] Step 8.11: Handle `AUTH_REQUIRED`
 
 ---
  imports/ui/components/socially/socially.js | 15 ++++++++++++++-
@@ -3189,10 +3189,10 @@ index 2cc775f..61c86d1 100644
 2.5.0
 
 
-From 4c70b8461b420fcfde7777e36f4af14e1d6c39e1 Mon Sep 17 00:00:00 2001
+From 4931d03fb1fa88b18fb441277afbd42606983f91 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:08:59 +0200
-Subject: [PATCH 093/303] Step 9.1: Remove `autopublish`
+Subject: [PATCH 093/356] Step 9.1: Remove `autopublish`
 
 ---
  .meteor/packages | 1 -
@@ -3212,25 +3212,25 @@ index 0af80ec..110dde9 100644
  angular-templates
  sanjo:jasmine
 diff --git a/.meteor/versions b/.meteor/versions
-index 39637f1..2d7c2e7 100644
+index feb6048..9607f4c 100644
 --- a/.meteor/versions
 +++ b/.meteor/versions
 @@ -8,7 +8,6 @@ accounts-ui-unstyled@1.1.10
- allow-deny@1.0.2
+ allow-deny@1.0.4
  amplify@1.0.0
  angular-templates@1.0.2
--autopublish@1.0.5
- autoupdate@1.2.6
- babel-compiler@6.5.2
- babel-runtime@0.1.6
+-autopublish@1.0.7
+ autoupdate@1.2.8
+ babel-compiler@6.6.4
+ babel-runtime@0.1.8
 -- 
 2.5.0
 
 
-From 9da699c9fe5ee4bd30f454676593cd8406d84b54 Mon Sep 17 00:00:00 2001
+From 87f9323b1bf05206155db28100ced186d9b25173 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:14:30 +0200
-Subject: [PATCH 094/303] Step 9.2: Add the `parties` publication to the server
+Subject: [PATCH 094/356] Step 9.2: Add the `parties` publication to the server
 
 ---
  imports/api/parties/publish.js | 31 +++++++++++++++++++++++++++++++
@@ -3278,10 +3278,10 @@ index 0000000..590f23b
 2.5.0
 
 
-From 43732be1629e5f63eba15e3b7848607954908fa7 Mon Sep 17 00:00:00 2001
+From 0b926e681e99e94e228e650df075ae8fd50eb001 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:15:16 +0200
-Subject: [PATCH 095/303] Step 9.3: Move Parties to collection.js
+Subject: [PATCH 095/356] Step 9.3: Move Parties to collection.js
 
 ---
  imports/api/parties/collection.js | 15 +++++++++++++++
@@ -3313,10 +3313,10 @@ index 0000000..3e283c1
 2.5.0
 
 
-From 5d428de6ec6d8402e66cc512b88c03c516d3baba Mon Sep 17 00:00:00 2001
+From 3132bd0cffc6224f457093eeaaaeea737c0d4a5b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:15:55 +0200
-Subject: [PATCH 096/303] Step 9.4: Create entry point for Parties
+Subject: [PATCH 096/356] Step 9.4: Create entry point for Parties
 
 ---
  imports/api/parties/index.js | 3 +++
@@ -3336,10 +3336,10 @@ index 0000000..5f7ae00
 2.5.0
 
 
-From a94e53b2d487178d0d4b9010c69e1c42051a7eec Mon Sep 17 00:00:00 2001
+From 1f4bde85a178202d2d78f602d23242bb8f30137a Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:16:11 +0200
-Subject: [PATCH 097/303] Step 9.5: Remove old parties.js
+Subject: [PATCH 097/356] Step 9.5: Remove old parties.js
 
 ---
  imports/api/parties.js | 15 ---------------
@@ -3371,10 +3371,10 @@ index 3e283c1..0000000
 2.5.0
 
 
-From 966218f340bc23fd95456a1ed85ef992870ae523 Mon Sep 17 00:00:00 2001
+From e652e34a5149677479a7e8189c0b66656c5ba537 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:18:56 +0200
-Subject: [PATCH 098/303] Step 9.6: Add the `parties` subscription
+Subject: [PATCH 098/356] Step 9.6: Add the `parties` subscription
 
 ---
  imports/ui/components/partiesList/partiesList.js | 2 ++
@@ -3397,10 +3397,10 @@ index bc00317..9f51859 100644
 2.5.0
 
 
-From a54da563e16d005b12d4e865a2d7844d119d3f05 Mon Sep 17 00:00:00 2001
+From 97e47cce84c3231c0fb7fe1a20de91c716645715 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:20:20 +0200
-Subject: [PATCH 099/303] Step 9.7: Add public party checkbox to the add new
+Subject: [PATCH 099/356] Step 9.7: Add public party checkbox to the add new
  party form
 
 ---
@@ -3425,10 +3425,10 @@ index 3508bef..4db1888 100644
 2.5.0
 
 
-From 6b23c0ee3a46b512e07c7a7b77612ec90851e93c Mon Sep 17 00:00:00 2001
+From 1665eccc6eb822bbb09da0d2d667d37936169a3f Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:20:49 +0200
-Subject: [PATCH 100/303] Step 9.8: Add is public checkbox to the party details
+Subject: [PATCH 100/356] Step 9.8: Add is public checkbox to the party details
  view
 
 ---
@@ -3451,10 +3451,10 @@ index b5c939b..4e0cc68 100644
 2.5.0
 
 
-From 3f66739d4d6154ef13eeef71d1f544ef7b4726d9 Mon Sep 17 00:00:00 2001
+From 27acc8672ab01fe367984548ffe020e521728054 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:21:31 +0200
-Subject: [PATCH 101/303] Step 9.9: Add is public checkbox to the party details
+Subject: [PATCH 101/356] Step 9.9: Add is public checkbox to the party details
  component
 
 ---
@@ -3479,10 +3479,10 @@ index 12c05aa..678df71 100644
 2.5.0
 
 
-From 941e24d1986b2a11c5991120f32a71f9d5237864 Mon Sep 17 00:00:00 2001
+From 531dd7747dc5fe05f1e91c2e675c093c5770bb5b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:22:34 +0200
-Subject: [PATCH 102/303] Step 9.10: Add `parties` subscription to the
+Subject: [PATCH 102/356] Step 9.10: Add `parties` subscription to the
  PartyDetails
 
 ---
@@ -3506,10 +3506,10 @@ index 678df71..c11b395 100644
 2.5.0
 
 
-From c49ae4abc65785fd73e51b90c65287894db308db Mon Sep 17 00:00:00 2001
+From d152186ab2216a9adffbb81bc4066f6620642eed Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:24:09 +0200
-Subject: [PATCH 103/303] Step 9.11: Create the users publication
+Subject: [PATCH 103/356] Step 9.11: Create the users publication
 
 ---
  imports/api/users.js | 12 ++++++++++++
@@ -3538,10 +3538,10 @@ index 0000000..4c9fee9
 2.5.0
 
 
-From 986feb4f3c3866714d53377e629fb2e061924e98 Mon Sep 17 00:00:00 2001
+From 3d7e40b07611a2e369dc4c5b0879b0b41a86f32d Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:24:32 +0200
-Subject: [PATCH 104/303] Step 9.12: Add `users` publication to the server-side
+Subject: [PATCH 104/356] Step 9.12: Add `users` publication to the server-side
 
 ---
  server/main.js | 1 +
@@ -3559,10 +3559,10 @@ index d4c97f0..1acdc6c 100644
 2.5.0
 
 
-From dbf1bad5ee2b9adfdb7848c61f4e2ca7bf513727 Mon Sep 17 00:00:00 2001
+From d5da26d1c7425bf481a564a376f11ac08d29135b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:26:29 +0200
-Subject: [PATCH 105/303] Step 9.13: Add `users` subscription and helper
+Subject: [PATCH 105/356] Step 9.13: Add `users` subscription and helper
 
 ---
  imports/ui/components/partyDetails/partyDetails.js | 4 ++++
@@ -3593,10 +3593,10 @@ index c11b395..bbaa7d7 100644
 2.5.0
 
 
-From 72bf829d9d6b09b18af7f7337b6fafad9f3dc129 Mon Sep 17 00:00:00 2001
+From 3dc4c2e03364f69212812d9258a85dbbe2462433 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:27:20 +0200
-Subject: [PATCH 106/303] Step 9.14: Add the users list to the party details
+Subject: [PATCH 106/356] Step 9.14: Add the users list to the party details
  view
 
 ---
@@ -3622,10 +3622,10 @@ index 4e0cc68..99de077 100644
 2.5.0
 
 
-From f74eed7565882ecbf8b3919dc492cb2b0e4c4d76 Mon Sep 17 00:00:00 2001
+From 7e6f3db4ae00111b0ed64ec99385e678fb07af9b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 15:44:26 +0200
-Subject: [PATCH 107/303] Step 9.15: Update tests of PartyAdd
+Subject: [PATCH 107/356] Step 9.15: Update tests of PartyAdd
 
 ---
  imports/ui/components/partyAdd/client/partyAdd.tests.js | 16 ++++++++++++++--
@@ -3680,10 +3680,10 @@ index cc1d35e..3d27875 100644
 2.5.0
 
 
-From f66e2fd7e3412daa1ce5159cea4dcf1bc81106e2 Mon Sep 17 00:00:00 2001
+From 34865613f1247bd9a1b54b3df1cc3e2775a69a36 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 15:45:37 +0200
-Subject: [PATCH 108/303] Step 9.16: Update tests of PartyDetails
+Subject: [PATCH 108/356] Step 9.16: Update tests of PartyDetails
 
 ---
  imports/ui/components/partyDetails/client/partyDetails.tests.js | 6 ++++--
@@ -3717,10 +3717,10 @@ index 997304e..0f3aa3b 100644
 2.5.0
 
 
-From 36de6067af814b8a92a2925af54341b61562ce96 Mon Sep 17 00:00:00 2001
+From 7226ae4ba8a242ace589e790fc628ea830d9da67 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:29:01 +0200
-Subject: [PATCH 109/303] Step 11.1: Update the module initialization
+Subject: [PATCH 109/356] Step 11.1: Update the module initialization
 
 ---
  client/main.js | 17 ++++++++++++++++-
@@ -3755,10 +3755,10 @@ index 212f992..06731e1 100644
 2.5.0
 
 
-From 89cc58d684d51c383fdb35db487224ab786077cf Mon Sep 17 00:00:00 2001
+From dab953a2d64105f06c2f7eb644d72ae98c2b5537 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:29:45 +0200
-Subject: [PATCH 110/303] Step 11.2: Remove the ngApp and ngStrictDi
+Subject: [PATCH 110/356] Step 11.2: Remove the ngApp and ngStrictDi
 
 ---
  client/index.html | 2 +-
@@ -3780,10 +3780,10 @@ index 806f6ab..0a26426 100644
 2.5.0
 
 
-From 29c8e401607a67e8314e57db763aafd5cafd67fc Mon Sep 17 00:00:00 2001
+From 897c97b6a4344a1ef773d52572eac5813f6a9eb6 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:32:51 +0200
-Subject: [PATCH 111/303] Step 12.1: Add options to the parties publish
+Subject: [PATCH 111/356] Step 12.1: Add options to the parties publish
 
 ---
  imports/api/parties/publish.js | 4 ++--
@@ -3814,10 +3814,10 @@ index 590f23b..65b8f38 100644
 2.5.0
 
 
-From 297f0732b0897c531510dcd890cbc0253f123e45 Mon Sep 17 00:00:00 2001
+From 6144ecd19f533c76f4cbe406e92b9c31b5f05eff Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:33:40 +0200
-Subject: [PATCH 112/303] Step 12.2: Add the pagination default params
+Subject: [PATCH 112/356] Step 12.2: Add the pagination default params
 
 ---
  imports/ui/components/partiesList/partiesList.js | 6 ++++++
@@ -3844,10 +3844,10 @@ index 9f51859..a7a24ef 100644
 2.5.0
 
 
-From 1a61608885b3437c2ad6db7414d197316a7137e2 Mon Sep 17 00:00:00 2001
+From 4012e7ea5c0dd908cdad7789fc0c2ad19b5b3014 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:35:13 +0200
-Subject: [PATCH 113/303] Step 12.3: Add the params to the subscription
+Subject: [PATCH 113/356] Step 12.3: Add the params to the subscription
 
 ---
  imports/ui/components/partiesList/partiesList.js | 6 +++++-
@@ -3874,10 +3874,10 @@ index a7a24ef..f7c9a84 100644
 2.5.0
 
 
-From a56cac7531da0271a7581d4c96e44b487a02e3c4 Mon Sep 17 00:00:00 2001
+From aa22cf6fc337915835d1d758295f23cb18eff1db Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:36:07 +0200
-Subject: [PATCH 114/303] Step 12.4: Add the sort parameter to the collection
+Subject: [PATCH 114/356] Step 12.4: Add the sort parameter to the collection
  helper
 
 ---
@@ -3903,10 +3903,10 @@ index f7c9a84..8902025 100644
 2.5.0
 
 
-From a8c24054354cf5f7af978c4654499d2a8a9047c2 Mon Sep 17 00:00:00 2001
+From 5cd857d72e64347e8a10c9cc8be8fea22b1a88cb Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:37:39 +0200
-Subject: [PATCH 115/303] Step 12.5: Install `angular-utils-pagination`
+Subject: [PATCH 115/356] Step 12.5: Install `angular-utils-pagination`
 
 ---
  package.json | 1 +
@@ -3928,10 +3928,10 @@ index a9636f0..227b0f3 100644
 2.5.0
 
 
-From 7d48605fe554c8e0a19231dd23e5794de9eb9cf0 Mon Sep 17 00:00:00 2001
+From 455c2b377ac7e9457c34c0fde43d9b9c6dc896b3 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:38:35 +0200
-Subject: [PATCH 116/303] Step 12.6: Add new dependency
+Subject: [PATCH 116/356] Step 12.6: Add new dependency
 
 ---
  imports/ui/components/partiesList/partiesList.js | 2 ++
@@ -3961,10 +3961,10 @@ index 8902025..cc5358a 100644
 2.5.0
 
 
-From 8fda8958ebe4aa2e79b9efc8e4607648e7e63145 Mon Sep 17 00:00:00 2001
+From dea3327a92091fccfba8c6ed2d8b1a04cd33e41a Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:39:32 +0200
-Subject: [PATCH 117/303] Step 12.7: Add usage to the dir-pagination directive
+Subject: [PATCH 117/356] Step 12.7: Add usage to the dir-pagination directive
 
 ---
  imports/ui/components/partiesList/partiesList.html | 2 +-
@@ -3987,10 +3987,10 @@ index c1b07e2..71b36ae 100644
 2.5.0
 
 
-From 2646dbb8dea8e464f4a8d86701ec86aaf1362ad4 Mon Sep 17 00:00:00 2001
+From 20c8c9e82de0a51f3e76842f946718bbdb6cf719 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:39:54 +0200
-Subject: [PATCH 118/303] Step 12.8: Add the pagination controls to the view
+Subject: [PATCH 118/356] Step 12.8: Add the pagination controls to the view
 
 ---
  imports/ui/components/partiesList/partiesList.html | 2 ++
@@ -4010,10 +4010,10 @@ index 71b36ae..d4206d6 100644
 2.5.0
 
 
-From 9fd7c292c7ee84a388422aa0499efec8309bba3e Mon Sep 17 00:00:00 2001
+From 29c462c7b884c1cac596e3416df7d3357b92fc19 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:40:29 +0200
-Subject: [PATCH 119/303] Step 12.9: Add the pageChanged method to the
+Subject: [PATCH 119/356] Step 12.9: Add the pageChanged method to the
  component
 
 ---
@@ -4039,10 +4039,10 @@ index cc5358a..588727e 100644
 2.5.0
 
 
-From d9da14787fb7fe3fc5e38949b81846184dab63ea Mon Sep 17 00:00:00 2001
+From cc5968285d9eeeb3d0e6df7c7519ef722ace1873 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:41:20 +0200
-Subject: [PATCH 120/303] Step 12.10: Add `tmeasday:publish-counts`
+Subject: [PATCH 120/356] Step 12.10: Add `tmeasday:publish-counts`
 
 ---
  .meteor/packages | 1 +
@@ -4059,25 +4059,25 @@ index 110dde9..2525c04 100644
  accounts-twitter
 +tmeasday:publish-counts
 diff --git a/.meteor/versions b/.meteor/versions
-index 2d7c2e7..b44d0e4 100644
+index 9607f4c..7995fa7 100644
 --- a/.meteor/versions
 +++ b/.meteor/versions
-@@ -89,6 +89,7 @@ standard-minifier-js@1.0.4
+@@ -89,6 +89,7 @@ standard-minifier-js@1.0.6
  templating@1.1.7
  templating-tools@1.0.2
  tmeasday:check-npm-versions@0.1.1
 +tmeasday:publish-counts@0.7.3
- tracker@1.0.11
+ tracker@1.0.13
  twitter@1.1.7
- ui@1.0.9
+ ui@1.0.11
 -- 
 2.5.0
 
 
-From b7448442438a7daa6843e4c20976eb95f49a69d4 Mon Sep 17 00:00:00 2001
+From f3821ed0fd0e694d1f6257e00887ae12620d122c Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:42:27 +0200
-Subject: [PATCH 121/303] Step 12.11: Add usage of Counts
+Subject: [PATCH 121/356] Step 12.11: Add usage of Counts
 
 ---
  imports/api/parties/publish.js | 5 +++++
@@ -4108,10 +4108,10 @@ index 65b8f38..4932df2 100644
 2.5.0
 
 
-From cba3fa6386616a51da971e4be32c9da6b2fded3e Mon Sep 17 00:00:00 2001
+From 39a5bd0e0b699bd832dc5428b052d629b6ccc647 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:44:44 +0200
-Subject: [PATCH 122/303] Step 12.12: Add the Count usage in the component
+Subject: [PATCH 122/356] Step 12.12: Add the Count usage in the component
 
 ---
  imports/ui/components/partiesList/partiesList.js | 5 +++++
@@ -4144,10 +4144,10 @@ index 588727e..f0e20e8 100644
 2.5.0
 
 
-From ca035b777f22e3ace1b8ac4d471b1d4d86cf98f3 Mon Sep 17 00:00:00 2001
+From 4eda9d990599b78dcd1310d2b37b25f5c868ae84 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:47:04 +0200
-Subject: [PATCH 123/303] Step 12.13: Create view for PartiesSort component
+Subject: [PATCH 123/356] Step 12.13: Create view for PartiesSort component
 
 ---
  imports/ui/components/partiesSort/partiesSort.html | 6 ++++++
@@ -4170,10 +4170,10 @@ index 0000000..cf2102b
 2.5.0
 
 
-From ee1a29518510378eea95215286cb73ddc346584a Mon Sep 17 00:00:00 2001
+From f0beb09eda0071e5b460db1c1dff851a55df12ed Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:48:25 +0200
-Subject: [PATCH 124/303] Step 12.14: Create PartiesSort component
+Subject: [PATCH 124/356] Step 12.14: Create PartiesSort component
 
 ---
  imports/ui/components/partiesSort/partiesSort.js | 34 ++++++++++++++++++++++++
@@ -4224,10 +4224,10 @@ index 0000000..f18b84d
 2.5.0
 
 
-From 751ca90293d429ed792771ca1fd73b297b28f85b Mon Sep 17 00:00:00 2001
+From 5e63e0fca0da35143a72704f19f815dee2e4f5f9 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:49:26 +0200
-Subject: [PATCH 125/303] Step 12.15: Add as a dependency
+Subject: [PATCH 125/356] Step 12.15: Add as a dependency
 
 ---
  imports/ui/components/partiesList/partiesList.js | 2 ++
@@ -4257,10 +4257,10 @@ index f0e20e8..9d9f1bf 100644
 2.5.0
 
 
-From e4930469dce23486da3bfd729a22c6818864e7fe Mon Sep 17 00:00:00 2001
+From 7c777ade805e40d566bf7fecb2919699dc60d05c Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:50:20 +0200
-Subject: [PATCH 126/303] Step 12.16: Implement component
+Subject: [PATCH 126/356] Step 12.16: Implement component
 
 ---
  imports/ui/components/partiesList/partiesList.html | 2 ++
@@ -4282,10 +4282,10 @@ index d4206d6..0fe847e 100644
 2.5.0
 
 
-From 037255254fcaf7cfb0e480299a60e888abd9be46 Mon Sep 17 00:00:00 2001
+From a92c32e04e0f8e48f404c6794da87ff858e2c8d2 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 12:51:09 +0200
-Subject: [PATCH 127/303] Step 12.17: Handle sort changes
+Subject: [PATCH 127/356] Step 12.17: Handle sort changes
 
 ---
  imports/ui/components/partiesList/partiesList.js | 4 ++++
@@ -4310,10 +4310,10 @@ index 9d9f1bf..b222c3a 100644
 2.5.0
 
 
-From a8f8c472572972c7f2e547b3308ab9d2d780526a Mon Sep 17 00:00:00 2001
+From b22ea87bcef55fb7ef20e98ec23c108885e5fd4b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:12:35 +0200
-Subject: [PATCH 128/303] Step 12.18: Add searchString to `parties` publication
+Subject: [PATCH 128/356] Step 12.18: Add searchString to `parties` publication
 
 ---
  imports/api/parties/publish.js | 9 ++++++++-
@@ -4350,10 +4350,10 @@ index 4932df2..67c9bdb 100644
 2.5.0
 
 
-From 503f3d25de3aba4d5c9d4bd07d599cc2c2f39e0b Mon Sep 17 00:00:00 2001
+From 176db530dac67b41161baa3f7f89b192fa4c1542 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:15:46 +0200
-Subject: [PATCH 129/303] Step 12.19: Add searchText to subscription
+Subject: [PATCH 129/356] Step 12.19: Add searchText to subscription
 
 ---
  imports/ui/components/partiesList/partiesList.js | 8 +++++---
@@ -4384,10 +4384,10 @@ index b222c3a..ee2dc70 100644
 2.5.0
 
 
-From 91d8e76f444437bef0b9880c1f82eb7b01fc7317 Mon Sep 17 00:00:00 2001
+From 2483030797e3fbfa0f31aa11a8d27279d75aaec0 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:16:30 +0200
-Subject: [PATCH 130/303] Step 12.20: Add input with searchText as ngModel
+Subject: [PATCH 130/356] Step 12.20: Add input with searchText as ngModel
 
 ---
  imports/ui/components/partiesList/partiesList.html | 2 ++
@@ -4409,10 +4409,10 @@ index 0fe847e..3c411fe 100644
 2.5.0
 
 
-From 13390ac2612f03e5e44811d7e2568353558aefb2 Mon Sep 17 00:00:00 2001
+From 5dad31b9337f3b2f0f583156c1a616ff7a5effb6 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 15:59:07 +0200
-Subject: [PATCH 131/303] Step 12.21: Tests of PartiesSort
+Subject: [PATCH 131/356] Step 12.21: Tests of PartiesSort
 
 ---
  .../partiesSort/client/partiesSort.tests.js        | 54 ++++++++++++++++++++++
@@ -4483,10 +4483,10 @@ index 0000000..09d81b4
 2.5.0
 
 
-From 627ee55917d01d6d9342e1c395abf951020291fd Mon Sep 17 00:00:00 2001
+From f5813f1eab3e8849780d6fa1d69a8aa277a10a06 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:07:14 +0200
-Subject: [PATCH 132/303] Step 12.22: Tests of PartiesList
+Subject: [PATCH 132/356] Step 12.22: Tests of PartiesList
 
 ---
  .../partiesList/client/partiesList.tests.js        | 50 ++++++++++++++++++++++
@@ -4553,10 +4553,10 @@ index 0000000..176da85
 2.5.0
 
 
-From b1cfef941d13aa4edb99ef7b05b56a94b9713742 Mon Sep 17 00:00:00 2001
+From 4535e8f1e666d2d0b5ef314a376773e9c571742c Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:23:07 +0200
-Subject: [PATCH 133/303] Step 13.1: Create UninvitedFilter
+Subject: [PATCH 133/356] Step 13.1: Create UninvitedFilter
 
 ---
  imports/ui/filters/uninvitedFilter.js | 20 ++++++++++++++++++++
@@ -4593,10 +4593,10 @@ index 0000000..77528fc
 2.5.0
 
 
-From afdf8a63d2f3e0ab0d392fa681dbdd973d41b5d6 Mon Sep 17 00:00:00 2001
+From a6daa0d945527a34bf4e5dc2c33ade9414e7f1ee Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:24:04 +0200
-Subject: [PATCH 134/303] Step 13.2: Install `underscore`
+Subject: [PATCH 134/356] Step 13.2: Install `underscore`
 
 ---
  package.json | 3 ++-
@@ -4620,10 +4620,10 @@ index 227b0f3..6d220f0 100644
 2.5.0
 
 
-From 07c91efc1b6565cb8ddf8f4b4c79995424c87d12 Mon Sep 17 00:00:00 2001
+From ed60f469e1bb4305efb7054e30033ed7980afaf0 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:24:21 +0200
-Subject: [PATCH 135/303] Step 13.3: Use underscore
+Subject: [PATCH 135/356] Step 13.3: Use underscore
 
 ---
  imports/ui/filters/uninvitedFilter.js | 3 ++-
@@ -4652,10 +4652,10 @@ index 77528fc..cfe8d2d 100644
 2.5.0
 
 
-From fd350ff7552fc51d889ac2adb52319de80b518a2 Mon Sep 17 00:00:00 2001
+From c4cb20d62705f4ecac8c3e55b3e6bb1ca4f9f664 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:26:20 +0200
-Subject: [PATCH 136/303] Step 13.4: Move list of users to separate component
+Subject: [PATCH 136/356] Step 13.4: Move list of users to separate component
 
 ---
  imports/ui/components/partyUninvited/partyUninvited.html | 6 ++++++
@@ -4678,10 +4678,10 @@ index 0000000..ac0bbc7
 2.5.0
 
 
-From f1d9980cf81a3145086f6c693a66eee96ba12fad Mon Sep 17 00:00:00 2001
+From fc51ef7ec6be774e328486234dd6b181832f5683 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:30:02 +0200
-Subject: [PATCH 137/303] Step 13.5: Create PartyUninvited component
+Subject: [PATCH 137/356] Step 13.5: Create PartyUninvited component
 
 ---
  .../ui/components/partyUninvited/partyUninvited.js | 34 ++++++++++++++++++++++
@@ -4732,10 +4732,10 @@ index 0000000..36c99df
 2.5.0
 
 
-From c8218a25bf5269bc4fc58c78ac869ee3b4bbe7a4 Mon Sep 17 00:00:00 2001
+From cc94b76e87eea6a53b04abafc185c911a78bda4b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:30:46 +0200
-Subject: [PATCH 138/303] Step 13.6: Add UninvitedFilter
+Subject: [PATCH 138/356] Step 13.6: Add UninvitedFilter
 
 ---
  imports/ui/components/partyUninvited/partyUninvited.js | 4 +++-
@@ -4767,10 +4767,10 @@ index 36c99df..caba948 100644
 2.5.0
 
 
-From a940b20fc969ccded0f75faca470fb71a52979ab Mon Sep 17 00:00:00 2001
+From e68dcbb33547ace7ade9011f558a96d6f910edb5 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:31:26 +0200
-Subject: [PATCH 139/303] Step 13.7: Implement filter
+Subject: [PATCH 139/356] Step 13.7: Implement filter
 
 ---
  imports/ui/components/partyUninvited/partyUninvited.html | 4 ++--
@@ -4793,10 +4793,10 @@ index ac0bbc7..c1ccda5 100644
 2.5.0
 
 
-From a0e0676d0842d7417af1cbbad959e4fc2d257863 Mon Sep 17 00:00:00 2001
+From 532552e96e837bfcf7cc8c00910c1512cf3ed3a8 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:32:22 +0200
-Subject: [PATCH 140/303] Step 13.8: Implement component in PartyDetails view
+Subject: [PATCH 140/356] Step 13.8: Implement component in PartyDetails view
 
 ---
  imports/ui/components/partyDetails/partyDetails.html | 7 +------
@@ -4821,10 +4821,10 @@ index 99de077..916f23e 100644
 2.5.0
 
 
-From 4e0ff7fa58368947c996b560562a087dfdfcf362 Mon Sep 17 00:00:00 2001
+From 70b4b2d47ab707296c1868b264b825f9447772d5 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:33:20 +0200
-Subject: [PATCH 141/303] Step 13.9: Add to dependencies
+Subject: [PATCH 141/356] Step 13.9: Add to dependencies
 
 ---
  imports/ui/components/partyDetails/partyDetails.js | 4 +++-
@@ -4856,10 +4856,10 @@ index bbaa7d7..21bf1a3 100644
 2.5.0
 
 
-From 69e3b7fd3a9ae7478e53a5430a75be823de49b12 Mon Sep 17 00:00:00 2001
+From 7ac25689afaffd97ef95873926f5fc8b17ad4186 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:40:30 +0200
-Subject: [PATCH 142/303] Step 13.10: Create DisplayNameFilter
+Subject: [PATCH 142/356] Step 13.10: Create DisplayNameFilter
 
 ---
  imports/ui/filters/displayNameFilter.js | 25 +++++++++++++++++++++++++
@@ -4901,10 +4901,10 @@ index 0000000..57d9250
 2.5.0
 
 
-From efff4b4ac1567cd5f47a73fad8435d75dd9108eb Mon Sep 17 00:00:00 2001
+From 3b171041174de7a139764e9dd415faef8d74c46e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:41:15 +0200
-Subject: [PATCH 143/303] Step 13.11: Add as a dependency
+Subject: [PATCH 143/356] Step 13.11: Add as a dependency
 
 ---
  imports/ui/components/partyUninvited/partyUninvited.js | 4 +++-
@@ -4936,10 +4936,10 @@ index caba948..4ec5ade 100644
 2.5.0
 
 
-From be315fec5ca5bfd7ce9cb21c1558fbd6dec3c4af Mon Sep 17 00:00:00 2001
+From d167591e6e20ff6f5a8fe468b4f9777a4241b104 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:41:54 +0200
-Subject: [PATCH 144/303] Step 13.12: Use filter
+Subject: [PATCH 144/356] Step 13.12: Use filter
 
 ---
  imports/ui/components/partyUninvited/partyUninvited.html | 2 +-
@@ -4961,10 +4961,10 @@ index c1ccda5..9603f3a 100644
 2.5.0
 
 
-From 3a74fa0ee065037f5846c8610917d684ccc4af4b Mon Sep 17 00:00:00 2001
+From 7c097b6ae92400269c8051895fb98911684c9383 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:45:34 +0200
-Subject: [PATCH 145/303] Step 13.13: Create template for PartyCreator
+Subject: [PATCH 145/356] Step 13.13: Create template for PartyCreator
  component
 
 ---
@@ -4987,10 +4987,10 @@ index 0000000..de986fb
 2.5.0
 
 
-From 85b9dbb5c3039567186a66df4339961fe7e720e0 Mon Sep 17 00:00:00 2001
+From 0c7da8f2d8d3a1f678ac1eabcef9ae199a131e17 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:45:54 +0200
-Subject: [PATCH 146/303] Step 13.14: Create PartyCreator component
+Subject: [PATCH 146/356] Step 13.14: Create PartyCreator component
 
 ---
  imports/ui/components/partyCreator/partyCreator.js | 49 ++++++++++++++++++++++
@@ -5056,10 +5056,10 @@ index 0000000..4f764b0
 2.5.0
 
 
-From 55e111f079257090eef106a8ffebb653022b618e Mon Sep 17 00:00:00 2001
+From f4d27a8d6cf4e83248d2e5c94562ddfbafd5d3b9 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:46:14 +0200
-Subject: [PATCH 147/303] Step 13.15: Implement component
+Subject: [PATCH 147/356] Step 13.15: Implement component
 
 ---
  imports/ui/components/partiesList/partiesList.html | 1 +
@@ -5081,10 +5081,10 @@ index 3c411fe..2b18723 100644
 2.5.0
 
 
-From a13fd8586c8aa184b1579c8baaab7888e80f9387 Mon Sep 17 00:00:00 2001
+From d85936bc14cfc14e2a1d3ee95afc180772edb9bc Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 16:46:39 +0200
-Subject: [PATCH 148/303] Step 13.16: Add as a dependency
+Subject: [PATCH 148/356] Step 13.16: Add as a dependency
 
 ---
  imports/ui/components/partiesList/partiesList.js | 4 +++-
@@ -5116,10 +5116,10 @@ index ee2dc70..b84a560 100644
 2.5.0
 
 
-From 577c444a4dfc48c761800da110f990a2a3a2de3b Mon Sep 17 00:00:00 2001
+From f329308d1ea845dcd59006f9d5c9487635b70e20 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:06:21 +0200
-Subject: [PATCH 149/303] Step 13.17: Tests of PartyCreator
+Subject: [PATCH 149/356] Step 13.17: Tests of PartyCreator
 
 ---
  .../partyCreator/client/partyCreator.tests.js      | 81 ++++++++++++++++++++++
@@ -5217,10 +5217,10 @@ index 0000000..dabb0b5
 2.5.0
 
 
-From a8b1558c6410426d67fce01c8f8dbf3872a59191 Mon Sep 17 00:00:00 2001
+From fd214335a745339412ee8aa44ff301a023799631 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:18:32 +0200
-Subject: [PATCH 150/303] Step 14.1: Add `check` package
+Subject: [PATCH 150/356] Step 14.1: Add `check` package
 
 ---
  .meteor/packages | 1 +
@@ -5239,10 +5239,10 @@ index 2525c04..3545268 100644
 2.5.0
 
 
-From 7826efffa2616d46e690e93a8740cd7971db8a72 Mon Sep 17 00:00:00 2001
+From 1cb87009c72917be3ca52240585bbe9330e6d1e7 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:21:04 +0200
-Subject: [PATCH 151/303] Step 14.2: Create invite method
+Subject: [PATCH 151/356] Step 14.2: Create invite method
 
 ---
  imports/api/parties/methods.js | 66 ++++++++++++++++++++++++++++++++++++++++++
@@ -5325,10 +5325,10 @@ index 0000000..dd75692
 2.5.0
 
 
-From 241431ad06227c08f26087380a4749c85c7d2e27 Mon Sep 17 00:00:00 2001
+From 8e9437e650c7c5d11790c77394ac7f5a68e3230c Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:21:28 +0200
-Subject: [PATCH 152/303] Step 14.3: Import methods
+Subject: [PATCH 152/356] Step 14.3: Import methods
 
 ---
  imports/api/parties/index.js | 1 +
@@ -5347,10 +5347,10 @@ index 5f7ae00..96b72b2 100644
 2.5.0
 
 
-From c44154216aaeb691d6ee4fa6e6324f335bfaab8c Mon Sep 17 00:00:00 2001
+From 6caa2ca71abd92490db0ec14221fefabafc6e9dd Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:23:05 +0200
-Subject: [PATCH 153/303] Step 14.4: Add `email` package
+Subject: [PATCH 153/356] Step 14.4: Add `email` package
 
 ---
  .meteor/packages | 1 +
@@ -5369,10 +5369,10 @@ index 3545268..53045cd 100644
 2.5.0
 
 
-From 2eff3d6b13ac1663acc3d102d36b35b4c0c710be Mon Sep 17 00:00:00 2001
+From d852c0c244b5bdf5d180bf0fac6dab5127bdc4bb Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:23:49 +0200
-Subject: [PATCH 154/303] Step 14.5: Import email from module
+Subject: [PATCH 154/356] Step 14.5: Import email from module
 
 ---
  imports/api/parties/methods.js | 1 +
@@ -5394,10 +5394,10 @@ index dd75692..054b42a 100644
 2.5.0
 
 
-From 9f0da4b8976a6bd99afe2ecc94d9d1901849334e Mon Sep 17 00:00:00 2001
+From cd3e6659837fab2f7e0f48cfbabcb450a668b0dd Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:25:59 +0200
-Subject: [PATCH 155/303] Step 14.6: Add invite method to PartyUninvited
+Subject: [PATCH 155/356] Step 14.6: Add invite method to PartyUninvited
 
 ---
  imports/ui/components/partyUninvited/partyUninvited.js | 12 ++++++++++++
@@ -5430,10 +5430,10 @@ index 4ec5ade..d941e40 100644
 2.5.0
 
 
-From da1c799fa96cede4df1dc95654a5534fe4300b8c Mon Sep 17 00:00:00 2001
+From 95ce4db4fe8547eefd553078ac7deb9da90e5c42 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:26:36 +0200
-Subject: [PATCH 156/303] Step 14.7: Add invite button
+Subject: [PATCH 156/356] Step 14.7: Add invite button
 
 ---
  imports/ui/components/partyUninvited/partyUninvited.html | 1 +
@@ -5454,10 +5454,10 @@ index 9603f3a..0cbb435 100644
 2.5.0
 
 
-From ef22143a96ffb72fd087f3d6b2b8fd0ae9138f15 Mon Sep 17 00:00:00 2001
+From 9272cc631302f047478674c942945f7a7937069f Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:28:47 +0200
-Subject: [PATCH 157/303] Step 14.8: Update the parties subscription to include
+Subject: [PATCH 157/356] Step 14.8: Update the parties subscription to include
  invited
 
 ---
@@ -5488,10 +5488,10 @@ index 67c9bdb..0d4d340 100644
 2.5.0
 
 
-From bd5bebdf24daa5c0a2fa544ae6091378db2903dd Mon Sep 17 00:00:00 2001
+From a67383b0afc893ad3efaf3d77a3a46df4e80d1f5 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:42:35 +0200
-Subject: [PATCH 158/303] Step 14.9: Add rsvp method
+Subject: [PATCH 158/356] Step 14.9: Add rsvp method
 
 ---
  imports/api/parties/methods.js | 79 +++++++++++++++++++++++++++++++++++++++++-
@@ -5590,10 +5590,10 @@ index 054b42a..e8aa1ad 100644
 2.5.0
 
 
-From 12783931ff7287a7072c6cd3bb0a25824427e779 Mon Sep 17 00:00:00 2001
+From d0527bc3db25f95ece67b6a8ceadec68b1f79a42 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:45:36 +0200
-Subject: [PATCH 159/303] Step 14.10: Create PartyRsvp component
+Subject: [PATCH 159/356] Step 14.10: Create PartyRsvp component
 
 ---
  imports/ui/components/partyRsvp/partyRsvp.js | 44 ++++++++++++++++++++++++++++
@@ -5654,10 +5654,10 @@ index 0000000..e5907b2
 2.5.0
 
 
-From 1d957b0ab6ac99ac5fa3007293121aebc7d06743 Mon Sep 17 00:00:00 2001
+From 1da338dbc3a3508af21c44fdc51e39c7a6026703 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:46:38 +0200
-Subject: [PATCH 160/303] Step 14.11: Create template
+Subject: [PATCH 160/356] Step 14.11: Create template
 
 ---
  imports/ui/components/partyRsvp/partyRsvp.html | 3 +++
@@ -5677,10 +5677,10 @@ index 0000000..ca15260
 2.5.0
 
 
-From 329db0d1535777dfc3f4553cfb4408048635d8b0 Mon Sep 17 00:00:00 2001
+From ca63a2f310cde6f0319cc2dc0ebaf8ce36298b10 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:48:22 +0200
-Subject: [PATCH 161/303] Step 14.12: Add component to the view
+Subject: [PATCH 161/356] Step 14.12: Add component to the view
 
 ---
  imports/ui/components/partiesList/partiesList.html | 1 +
@@ -5702,10 +5702,10 @@ index 2b18723..bced521 100644
 2.5.0
 
 
-From 821d30033228fd193dac56715521dfd7b238a585 Mon Sep 17 00:00:00 2001
+From 9e3e09f2f8c99855da8f7f008ce4a05a42276588 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:48:36 +0200
-Subject: [PATCH 162/303] Step 14.13: Add as a dependency
+Subject: [PATCH 162/356] Step 14.13: Add as a dependency
 
 ---
  imports/ui/components/partiesList/partiesList.js | 4 +++-
@@ -5737,10 +5737,10 @@ index b84a560..3ef39cd 100644
 2.5.0
 
 
-From 479e2e1cac71c7eb2dcfa6984b46925083166642 Mon Sep 17 00:00:00 2001
+From 3ada22be9a1409a3fd618e9df74945e0418bb871 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:53:02 +0200
-Subject: [PATCH 163/303] Step 14.14: Create view for PartyRsvpsList component
+Subject: [PATCH 163/356] Step 14.14: Create view for PartyRsvpsList component
 
 ---
  imports/ui/components/partyRsvpsList/partyRsvpsList.html | 6 ++++++
@@ -5763,10 +5763,10 @@ index 0000000..efc38ed
 2.5.0
 
 
-From 99049a96d791b3fb197afac8fa837b3e6e0ea9bd Mon Sep 17 00:00:00 2001
+From 326d493cce24a909bce10c4c2cf77f7c97127cb9 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:53:16 +0200
-Subject: [PATCH 164/303] Step 14.15: Create component
+Subject: [PATCH 164/356] Step 14.15: Create component
 
 ---
  .../ui/components/partyRsvpsList/partyRsvpsList.js   | 20 ++++++++++++++++++++
@@ -5803,10 +5803,10 @@ index 0000000..4e6e752
 2.5.0
 
 
-From 48a00a44d41dd8b75a6f5fdcb4631a1617a3c1ac Mon Sep 17 00:00:00 2001
+From 03451e144daf8aa9e340c99450144256d849555a Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:53:32 +0200
-Subject: [PATCH 165/303] Step 14.16: Add to the view
+Subject: [PATCH 165/356] Step 14.16: Add to the view
 
 ---
  imports/ui/components/partiesList/partiesList.html | 1 +
@@ -5828,10 +5828,10 @@ index bced521..60dbea3 100644
 2.5.0
 
 
-From cd2cfdc5bc5c2830934a08b85a8baf6239556c54 Mon Sep 17 00:00:00 2001
+From 7569f70277f97d96625f27debc427e9932d16c7b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:53:47 +0200
-Subject: [PATCH 166/303] Step 14.17: Also as a dependency
+Subject: [PATCH 166/356] Step 14.17: Also as a dependency
 
 ---
  imports/ui/components/partiesList/partiesList.js | 4 +++-
@@ -5863,10 +5863,10 @@ index 3ef39cd..2d27cfd 100644
 2.5.0
 
 
-From 26cb7893177b9d981f2087b8ec46f6e0cb50a70d Mon Sep 17 00:00:00 2001
+From ca87ae25518c715f4cfc3af607becfcd4e1df794 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:57:13 +0200
-Subject: [PATCH 167/303] Step 14.18: Create view for PartyRsvpUsers component
+Subject: [PATCH 167/356] Step 14.18: Create view for PartyRsvpUsers component
 
 ---
  imports/ui/components/partyRsvpUsers/partyRsvpUsers.html | 5 +++++
@@ -5888,10 +5888,10 @@ index 0000000..445d426
 2.5.0
 
 
-From bd311149cf4f3a46eaeabd13b95ab339deeb3ebd Mon Sep 17 00:00:00 2001
+From 458ac13b3210461bcf11b86aa91352521d13c20e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:57:30 +0200
-Subject: [PATCH 168/303] Step 14.19: Create component
+Subject: [PATCH 168/356] Step 14.19: Create component
 
 ---
  .../ui/components/partyRsvpUsers/partyRsvpUsers.js | 29 ++++++++++++++++++++++
@@ -5937,10 +5937,10 @@ index 0000000..f94eb18
 2.5.0
 
 
-From 842c145dd20e328a05004782ea64f95c5f9b67e3 Mon Sep 17 00:00:00 2001
+From f6e4b922f4b1a43293f36a13ed92ad707f03445a Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:57:56 +0200
-Subject: [PATCH 169/303] Step 14.20: Use recently created component
+Subject: [PATCH 169/356] Step 14.20: Use recently created component
 
 ---
  imports/ui/components/partyRsvpsList/partyRsvpsList.html | 4 ++++
@@ -5962,10 +5962,10 @@ index efc38ed..2e1749d 100644
 2.5.0
 
 
-From 75a3c21f99e2f7210394628a8cfd898bae24ba0a Mon Sep 17 00:00:00 2001
+From 1c1cf4c496310e3db17185732d909f043509934d Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:58:15 +0200
-Subject: [PATCH 170/303] Step 14.21: Add as a dependency
+Subject: [PATCH 170/356] Step 14.21: Add as a dependency
 
 ---
  imports/ui/components/partyRsvpsList/partyRsvpsList.js | 4 +++-
@@ -5997,10 +5997,10 @@ index 4e6e752..1150a47 100644
 2.5.0
 
 
-From d74a1345d8cdca660e6f719227972c70f3d0a6dc Mon Sep 17 00:00:00 2001
+From e6f2393bd1919ddbfb4b212e397e634707fbeacb Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 17:59:25 +0200
-Subject: [PATCH 171/303] Step 14.22: Create view for PartyUnanswered
+Subject: [PATCH 171/356] Step 14.22: Create view for PartyUnanswered
 
 ---
  imports/ui/components/partyUnanswered/partyUnanswered.html | 5 +++++
@@ -6022,10 +6022,10 @@ index 0000000..ecc1b45
 2.5.0
 
 
-From 2795ea155c63db16de56ddbc2931bde4d4a762a8 Mon Sep 17 00:00:00 2001
+From b417515e413906b5fd1081a6d0ccca87ada378a3 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 18:02:22 +0200
-Subject: [PATCH 172/303] Step 14.23: Create component
+Subject: [PATCH 172/356] Step 14.23: Create component
 
 ---
  .../components/partyUnanswered/partyUnanswered.js  | 39 ++++++++++++++++++++++
@@ -6081,10 +6081,10 @@ index 0000000..d6eaf46
 2.5.0
 
 
-From b03386bab1e7d157e51fb079c6f79e10a8dffd46 Mon Sep 17 00:00:00 2001
+From e1b38439a815a8070e1b39b0c966a3c7fee7267a Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 18:02:52 +0200
-Subject: [PATCH 173/303] Step 14.24: Use recently created component
+Subject: [PATCH 173/356] Step 14.24: Use recently created component
 
 ---
  imports/ui/components/partiesList/partiesList.html | 1 +
@@ -6106,10 +6106,10 @@ index 60dbea3..4881e5c 100644
 2.5.0
 
 
-From 25314c3e3d50ce68ab65c0feb11d1b2db687bd50 Mon Sep 17 00:00:00 2001
+From ff2ae029c48b8467f16412ceffab43ca15e6a29c Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 18:03:12 +0200
-Subject: [PATCH 174/303] Step 14.25: Add as a dependency
+Subject: [PATCH 174/356] Step 14.25: Add as a dependency
 
 ---
  imports/ui/components/partiesList/partiesList.js | 4 +++-
@@ -6141,10 +6141,10 @@ index 2d27cfd..bc983e5 100644
 2.5.0
 
 
-From fc18794185866c56d92f5154b7e935ada4ea1d1f Mon Sep 17 00:00:00 2001
+From 649fe852ee617e717642f9afb198b3caed73add0 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 18:03:38 +0200
-Subject: [PATCH 175/303] Step 14.26: Subscribe `users`
+Subject: [PATCH 175/356] Step 14.26: Subscribe `users`
 
 ---
  imports/ui/components/partiesList/partiesList.js | 2 ++
@@ -6167,10 +6167,10 @@ index bc983e5..5a10136 100644
 2.5.0
 
 
-From 966de79f567691b1af4684ab5c09f7670262e610 Mon Sep 17 00:00:00 2001
+From b7cac8b6555953f86a2c95e781a80787c92e3983 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 19:50:23 +0200
-Subject: [PATCH 176/303] Step 14.27: Tests of invite method
+Subject: [PATCH 176/356] Step 14.27: Tests of invite method
 
 ---
  imports/api/parties/methods.tests.js | 126 +++++++++++++++++++++++++++++++++++
@@ -6313,10 +6313,10 @@ index 0000000..56e770c
 2.5.0
 
 
-From bc0c062ee147b30231527116cb7147f042becc8b Mon Sep 17 00:00:00 2001
+From 27d369388cccb559ae0510ec5d5164dbd92620ab Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:00:03 +0200
-Subject: [PATCH 177/303] Step 14.28: Tests of rsvp Method
+Subject: [PATCH 177/356] Step 14.28: Tests of rsvp Method
 
 ---
  imports/api/parties/methods.tests.js | 54 +++++++++++++++++++++++++++++++++++-
@@ -6394,10 +6394,10 @@ index 56e770c..536a2b0 100644
 2.5.0
 
 
-From 574da9cb5e7b3ff08734370c661c17d40227e021 Mon Sep 17 00:00:00 2001
+From 060ddb85d11ea0be713bda2a6f42e2c0d1e225bc Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:07:36 +0200
-Subject: [PATCH 178/303] Step 15.1: Add ngShow to PartyAdd
+Subject: [PATCH 178/356] Step 15.1: Add ngShow to PartyAdd
 
 ---
  imports/ui/components/partiesList/partiesList.html | 2 +-
@@ -6417,10 +6417,10 @@ index 4881e5c..d6d4c83 100644
 2.5.0
 
 
-From 0adcaba8c2f33c999d4bc6197c8f2e9fcd7ffe3f Mon Sep 17 00:00:00 2001
+From c1d304e1a1a78eaccb8e0ab75c8390f44cf777f7 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:09:16 +0200
-Subject: [PATCH 179/303] Step 15.2: Add isLoggedIn helper
+Subject: [PATCH 179/356] Step 15.2: Add isLoggedIn helper
 
 ---
  imports/ui/components/partiesList/partiesList.js | 3 +++
@@ -6444,10 +6444,10 @@ index 5a10136..5f779e0 100644
 2.5.0
 
 
-From 9f2b6e607f09f997dc5a49e321631832fc97d2dd Mon Sep 17 00:00:00 2001
+From aac2548fc156b3065bbbb4b99e64f19f223c7b50 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:09:45 +0200
-Subject: [PATCH 180/303] Step 15.3: Add usage for ng-hide
+Subject: [PATCH 180/356] Step 15.3: Add usage for ng-hide
 
 ---
  imports/ui/components/partiesList/partiesList.html | 3 +++
@@ -6469,10 +6469,10 @@ index d6d4c83..c3006d3 100644
 2.5.0
 
 
-From 9299c235eb0deeef25f8df2ccc0d9d00772a32c1 Mon Sep 17 00:00:00 2001
+From 7188447bdb64d5c0a73efe92105361e4bf5336dc Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:10:23 +0200
-Subject: [PATCH 181/303] Step 15.4: Add ngShow to PartyRsvp
+Subject: [PATCH 181/356] Step 15.4: Add ngShow to PartyRsvp
 
 ---
  imports/ui/components/partiesList/partiesList.html | 2 +-
@@ -6495,10 +6495,10 @@ index c3006d3..07d331f 100644
 2.5.0
 
 
-From e0bdc7cf007c05cb98681be24cdda68c7b420962 Mon Sep 17 00:00:00 2001
+From 3fa3de7a04feb10afa5f4e21c5e38db44b6e7144 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:10:48 +0200
-Subject: [PATCH 182/303] Step 15.5: Add message for not-logged in users on the
+Subject: [PATCH 182/356] Step 15.5: Add message for not-logged in users on the
  RSVP buttons
 
 ---
@@ -6524,10 +6524,10 @@ index 07d331f..3b4a085 100644
 2.5.0
 
 
-From a660bc6be91ab88a9f99d6152cdcd549ae7ec013 Mon Sep 17 00:00:00 2001
+From 66b6605856829b8826c07d8b8ddcbedf03451c14 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:12:56 +0200
-Subject: [PATCH 183/303] Step 15.6: Add isOwner method
+Subject: [PATCH 183/356] Step 15.6: Add isOwner method
 
 ---
  imports/ui/components/partiesList/partiesList.js | 7 +++++++
@@ -6559,10 +6559,10 @@ index 5f779e0..f139a7a 100644
 2.5.0
 
 
-From 1bec74ede65d55fd984f19e3173a1f814946d2f3 Mon Sep 17 00:00:00 2001
+From d1daa29b4daa38592519f2a8b1a359021e3279f2 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:13:51 +0200
-Subject: [PATCH 184/303] Step 15.7: Add ngShow to PartyRemove
+Subject: [PATCH 184/356] Step 15.7: Add ngShow to PartyRemove
 
 ---
  imports/ui/components/partiesList/partiesList.html | 4 ++--
@@ -6591,10 +6591,10 @@ index 3b4a085..fbc61a9 100644
 2.5.0
 
 
-From 9aee2d912a524541b8557de7cde7eab93f1f3eca Mon Sep 17 00:00:00 2001
+From 74c0388d11a7900081143006834719a005c38031 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:15:08 +0200
-Subject: [PATCH 185/303] Step 15.8: Add ngIf to PartyUnanswered
+Subject: [PATCH 185/356] Step 15.8: Add ngIf to PartyUnanswered
 
 ---
  imports/ui/components/partiesList/partiesList.html | 7 ++++++-
@@ -6622,10 +6622,10 @@ index fbc61a9..c4cc2c1 100644
 2.5.0
 
 
-From 909a4bc5e61717aac2820dd68f6bdcfeb08c9e01 Mon Sep 17 00:00:00 2001
+From d0760639220cc17b69cc0e6a7f88754bcaf2f8e2 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:16:17 +0200
-Subject: [PATCH 186/303] Step 15.9: Add canInvite method to the component
+Subject: [PATCH 186/356] Step 15.9: Add canInvite method to the component
 
 ---
  imports/ui/components/partyDetails/partyDetails.js | 8 ++++++++
@@ -6654,10 +6654,10 @@ index 21bf1a3..db84949 100644
 2.5.0
 
 
-From a1a8ea480dba4418bbd7976c297e5cbee1a60d65 Mon Sep 17 00:00:00 2001
+From 857eba85b59115010ca6baa224b3e4d414041780 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:18:07 +0200
-Subject: [PATCH 187/303] Step 15.10: Add ngShow to PartyUninvited
+Subject: [PATCH 187/356] Step 15.10: Add ngShow to PartyUninvited
 
 ---
  imports/ui/components/partyDetails/partyDetails.html | 2 +-
@@ -6677,10 +6677,10 @@ index 916f23e..ab7abd9 100644
 2.5.0
 
 
-From 4e02fb7a5840def2c08d8fcbe06a301f560da03b Mon Sep 17 00:00:00 2001
+From cf1f43afc35a5760d39b3f42d53ddaa4d9bdbc7c Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:18:54 +0200
-Subject: [PATCH 188/303] Step 15.11: Add info that everyone are already
+Subject: [PATCH 188/356] Step 15.11: Add info that everyone are already
  invited
 
 ---
@@ -6703,10 +6703,10 @@ index 0cbb435..86d2519 100644
 2.5.0
 
 
-From 2277ba9836865925f7b23168c67d38a32f6fc1c9 Mon Sep 17 00:00:00 2001
+From 141ef0099224b30b1e6176fa9f40637a24456e62 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:19:54 +0200
-Subject: [PATCH 189/303] Step 15.12: Add isLoggedIn helper to the party
+Subject: [PATCH 189/356] Step 15.12: Add isLoggedIn helper to the party
  details component
 
 ---
@@ -6731,10 +6731,10 @@ index db84949..b922b82 100644
 2.5.0
 
 
-From a2c63b375ad74d11023a335782462e14e33f94e2 Mon Sep 17 00:00:00 2001
+From b8e70029dab9f5b44534e1e2c6b9008ba8fdee92 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:20:39 +0200
-Subject: [PATCH 190/303] Step 15.13: Add usage for ng-disabled
+Subject: [PATCH 190/356] Step 15.13: Add usage for ng-disabled
 
 ---
  imports/ui/components/partyDetails/partyDetails.html | 6 +++---
@@ -6760,10 +6760,10 @@ index ab7abd9..e53812d 100644
 2.5.0
 
 
-From 5edce667343bbbb961b605ad3d71be34306514cb Mon Sep 17 00:00:00 2001
+From 014fc16079f6be5e7117276dc1d442c5448f9605 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:22:55 +0200
-Subject: [PATCH 191/303] Step 16.1: Install `angular-google-maps`
+Subject: [PATCH 191/356] Step 16.1: Install `angular-google-maps`
 
 ---
  package.json | 1 +
@@ -6785,10 +6785,10 @@ index 6d220f0..2a644d9 100644
 2.5.0
 
 
-From 948de91bd1f747dda8b4326fa29af839c5c0f2f6 Mon Sep 17 00:00:00 2001
+From d2c845b58e52e2b666376e491316da86857d9ff3 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:23:36 +0200
-Subject: [PATCH 192/303] Step 16.2: Install `angular-simple-logger`
+Subject: [PATCH 192/356] Step 16.2: Install `angular-simple-logger`
 
 ---
  package.json | 1 +
@@ -6810,10 +6810,10 @@ index 2a644d9..1bb773a 100644
 2.5.0
 
 
-From 8975e2a24a4128f0ad8af90ce527f738b5d6692f Mon Sep 17 00:00:00 2001
+From 81f79489d2bb9a6090a789047e2806c3155564dd Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:24:57 +0200
-Subject: [PATCH 193/303] Step 16.3: Create template for PartyMap
+Subject: [PATCH 193/356] Step 16.3: Create template for PartyMap
 
 ---
  imports/ui/components/partyMap/partyMap.html | 5 +++++
@@ -6835,10 +6835,10 @@ index 0000000..e590420
 2.5.0
 
 
-From d9d1a1e40fb21e4f39a3d4b2ae615a217b2e93aa Mon Sep 17 00:00:00 2001
+From e61cda175ad1eecb0811fd4b48eb49846ce6235f Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:25:56 +0200
-Subject: [PATCH 194/303] Step 16.4: Create component
+Subject: [PATCH 194/356] Step 16.4: Create component
 
 ---
  imports/ui/components/partyMap/partyMap.js | 44 ++++++++++++++++++++++++++++++
@@ -6899,10 +6899,10 @@ index 0000000..73c6163
 2.5.0
 
 
-From 15ecb00e621a2857e0e30b5e2e5a5b6d7e8d43d6 Mon Sep 17 00:00:00 2001
+From e4c1b97ffb135dd34348a132bd49cdaaf39bc4d8 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:27:32 +0200
-Subject: [PATCH 195/303] Step 16.5: Add some class
+Subject: [PATCH 195/356] Step 16.5: Add some class
 
 ---
  imports/ui/components/partyMap/partyMap.css | 4 ++++
@@ -6923,10 +6923,10 @@ index 0000000..f4b49f5
 2.5.0
 
 
-From 26bd919f15b273587a98bc12567666622d3a3d48 Mon Sep 17 00:00:00 2001
+From 6db5b2cd5e4d6c7bcf76285939d59449f54778c8 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:28:08 +0200
-Subject: [PATCH 196/303] Step 16.6: Import styles
+Subject: [PATCH 196/356] Step 16.6: Import styles
 
 ---
  imports/ui/components/partyMap/partyMap.js | 1 +
@@ -6948,10 +6948,10 @@ index 73c6163..393fc10 100644
 2.5.0
 
 
-From a03cfc7b41b7a16d163477eba97d4aae8fc5f596 Mon Sep 17 00:00:00 2001
+From 974bb391ae9433d634e1106b11bad33dc76053a8 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:29:34 +0200
-Subject: [PATCH 197/303] Step 16.7: Add as a dependency to PartyDetails
+Subject: [PATCH 197/356] Step 16.7: Add as a dependency to PartyDetails
 
 ---
  imports/ui/components/partyDetails/partyDetails.js | 4 +++-
@@ -6983,10 +6983,10 @@ index b922b82..0d125cc 100644
 2.5.0
 
 
-From ef65699ad919b750a4dfbd198607463997fe4191 Mon Sep 17 00:00:00 2001
+From ac1e6ca5834dfe98d0685be7438ccaaae407248e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:42:54 +0200
-Subject: [PATCH 198/303] Step 16.8: Use in the view
+Subject: [PATCH 198/356] Step 16.8: Use in the view
 
 ---
  imports/ui/components/partyDetails/partyDetails.html | 2 ++
@@ -7006,10 +7006,10 @@ index e53812d..7354dd6 100644
 2.5.0
 
 
-From 517c093ba9d0789a89b2e9b99e5870740be2e204 Mon Sep 17 00:00:00 2001
+From dfa72ffc522f887031e899631851c758aa2011e6 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:44:36 +0200
-Subject: [PATCH 199/303] Step 16.9: Add actions
+Subject: [PATCH 199/356] Step 16.9: Add actions
 
 ---
  imports/ui/components/partyMap/partyMap.js | 21 +++++++++++++++++++--
@@ -7057,10 +7057,10 @@ index 393fc10..5fe2dfa 100644
 2.5.0
 
 
-From 3799247052709a68db3f68c5eebeae7dd371ca6b Mon Sep 17 00:00:00 2001
+From e497e3fca63c730e6e2a78ae336c8231f8c0b380 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:45:34 +0200
-Subject: [PATCH 200/303] Step 16.10: Add location to be updated with a party
+Subject: [PATCH 200/356] Step 16.10: Add location to be updated with a party
 
 ---
  imports/ui/components/partyDetails/partyDetails.js | 3 ++-
@@ -7084,10 +7084,10 @@ index 0d125cc..259012b 100644
 2.5.0
 
 
-From 3bce797a11dc264d13b9193aed2ed8d18b235cfd Mon Sep 17 00:00:00 2001
+From 95d7dd2864dd704d638d4dd9500b3d6a21ac9218 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:49:27 +0200
-Subject: [PATCH 201/303] Step 16.11: Create view for PartiesMap
+Subject: [PATCH 201/356] Step 16.11: Create view for PartiesMap
 
 ---
  imports/ui/components/partiesMap/partiesMap.html | 5 +++++
@@ -7109,10 +7109,10 @@ index 0000000..a488738
 2.5.0
 
 
-From 21c74e4b9c18bd159a4e114227cf48e7d72821d8 Mon Sep 17 00:00:00 2001
+From e954a51a919f9e400822ac0dea3ec9db79e0e329 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:49:42 +0200
-Subject: [PATCH 202/303] Step 16.12: Create component
+Subject: [PATCH 202/356] Step 16.12: Create component
 
 ---
  imports/ui/components/partiesMap/partiesMap.js | 37 ++++++++++++++++++++++++++
@@ -7166,10 +7166,10 @@ index 0000000..6759672
 2.5.0
 
 
-From 5ad1c4176b0ae0fa3d98ffa1a56da058e75a2971 Mon Sep 17 00:00:00 2001
+From 313e6ac22606c74ced3c6c36a103621ad71b87a4 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:49:56 +0200
-Subject: [PATCH 203/303] Step 16.13: Add as a dependency
+Subject: [PATCH 203/356] Step 16.13: Add as a dependency
 
 ---
  imports/ui/components/partiesList/partiesList.js | 2 ++
@@ -7199,10 +7199,10 @@ index f139a7a..9a1811b 100644
 2.5.0
 
 
-From 66ce9d67d3db32f3d4dfaefea485b455462c360e Mon Sep 17 00:00:00 2001
+From 08aaac5205bdc8dcd6d62885b51ea7491ad0e03d Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Thu, 7 Apr 2016 20:50:10 +0200
-Subject: [PATCH 204/303] Step 16.14: Implement in the view
+Subject: [PATCH 204/356] Step 16.14: Implement in the view
 
 ---
  imports/ui/components/partiesList/partiesList.html | 3 +++
@@ -7223,24 +7223,24 @@ index c4cc2c1..a7984f6 100644
 2.5.0
 
 
-From b6d8f920582d7795acfa67ac57bde8cb93048619 Mon Sep 17 00:00:00 2001
+From 5f9699297201e8a797394abaa343d00c23205773 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 00:31:49 +0200
-Subject: [PATCH 205/303] Step 17.1: Install `bootstrap`
+Subject: [PATCH 205/356] Step 17.1: Install `bootstrap`
 
 ---
  package.json | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/package.json b/package.json
-index 1bb773a..0b41357 100644
+index 1bb773a..9f874c7 100644
 --- a/package.json
 +++ b/package.json
 @@ -12,6 +12,7 @@
      "angular-simple-logger": "^0.1.7",
      "angular-ui-router": "^1.0.0-alpha.4",
      "angular-utils-pagination": "^0.11.1",
-+    "bootstrap4-webpack-package": "^1.0.0",
++    "bootstrap": "^4.0.0-alpha.2",
      "meteor-node-stubs": "~0.2.0",
      "underscore": "^1.8.3"
    },
@@ -7248,10 +7248,10 @@ index 1bb773a..0b41357 100644
 2.5.0
 
 
-From 95e4a7344b175af40ffba59837061c496939c14d Mon Sep 17 00:00:00 2001
+From dd50a78fc970c4e9128c82e08e86b74ccc4a8b54 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 00:32:37 +0200
-Subject: [PATCH 206/303] Step 17.2: Add `less` package
+Subject: [PATCH 206/356] Step 17.2: Add `less` package
 
 ---
  .meteor/packages | 1 +
@@ -7270,10 +7270,10 @@ index 53045cd..1b86693 100644
 2.5.0
 
 
-From 512c6bbb416cbc1118c357147c04ec28da2c421f Mon Sep 17 00:00:00 2001
+From f6cb24187d1623f44f4c360bab8af7ab854fa0ff Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 00:34:27 +0200
-Subject: [PATCH 207/303] Step 17.3: Add main.less
+Subject: [PATCH 207/356] Step 17.3: Add main.less
 
 ---
  client/main.less | 3 +++
@@ -7293,22 +7293,22 @@ index 0000000..1c1bc90
 2.5.0
 
 
-From 81ff1bc56b69e71def5a54156178be23fdc8dca3 Mon Sep 17 00:00:00 2001
+From 39aa99926d21bcf813d1b3f4bf3db58ce4e06eaa Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:03:30 +0200
-Subject: [PATCH 208/303] Step 17.4: Import bootstrap
+Subject: [PATCH 208/356] Step 17.4: Import bootstrap
 
 ---
  client/main.js | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/client/main.js b/client/main.js
-index 06731e1..a1d63f6 100644
+index 06731e1..52cb827 100644
 --- a/client/main.js
 +++ b/client/main.js
 @@ -1,4 +1,5 @@
  import angular from 'angular';
-+import 'bootstrap4-webpack-package';
++import 'bootstrap/dist/css/bootstrap.css';
  
  import { Meteor } from 'meteor/meteor';
  
@@ -7316,10 +7316,10 @@ index 06731e1..a1d63f6 100644
 2.5.0
 
 
-From 09f5dbb22b76beaa53363fe208824f7b1686a6e2 Mon Sep 17 00:00:00 2001
+From 69d8e4fa6fc5923f20d14b90d108d358b55d3bb4 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:04:28 +0200
-Subject: [PATCH 209/303] Step 17.5: Import future Socially less file
+Subject: [PATCH 209/356] Step 17.5: Import future Socially less file
 
 ---
  client/main.less | 2 ++
@@ -7339,10 +7339,10 @@ index 1c1bc90..4368004 100644
 2.5.0
 
 
-From f8635b4db177fe9a0033edabaaad2e471a1e3311 Mon Sep 17 00:00:00 2001
+From df256812b394f048c7987012dc6474e0d4b77579 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:05:42 +0200
-Subject: [PATCH 210/303] Step 17.6: Refactor Socially
+Subject: [PATCH 210/356] Step 17.6: Refactor Socially
 
 ---
  imports/ui/components/socially/socially.html | 6 ++----
@@ -7364,10 +7364,10 @@ index 83c40e7..2e91050 100644
 2.5.0
 
 
-From 5ff82ba77180a73ed703440589d60c2300809b56 Mon Sep 17 00:00:00 2001
+From cb28a5506ab485e8308a94c6af017a5fc5c87109 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:06:24 +0200
-Subject: [PATCH 211/303] Step 17.7: Styles for Socially
+Subject: [PATCH 211/356] Step 17.7: Styles for Socially
 
 ---
  imports/ui/components/socially/socially.less | 3 +++
@@ -7387,10 +7387,10 @@ index 0000000..eec0480
 2.5.0
 
 
-From a7c26003e46314b6236eee929082bce648cdab5c Mon Sep 17 00:00:00 2001
+From b79c14a9ce8a93db157d41d22fbd2554a274abad Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:06:51 +0200
-Subject: [PATCH 212/303] Step 17.8: Refactor index.html
+Subject: [PATCH 212/356] Step 17.8: Refactor index.html
 
 ---
  client/index.html | 5 +++++
@@ -7415,10 +7415,10 @@ index 0a26426..d4505ca 100644
 2.5.0
 
 
-From 1b3152e693b278ff52422bd8380e2e484ca9cf27 Mon Sep 17 00:00:00 2001
+From 13e72e57e4772781f063e97a01a436cd5689a96b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:07:16 +0200
-Subject: [PATCH 213/303] Step 17.9: Refactor Navigation
+Subject: [PATCH 213/356] Step 17.9: Refactor Navigation
 
 ---
  imports/ui/components/navigation/navigation.html | 9 ++++++---
@@ -7442,10 +7442,10 @@ index def2640..2bcae64 100644
 2.5.0
 
 
-From 4574a92c62aeac0bc4ca6ac6c6d29f6f96a250cc Mon Sep 17 00:00:00 2001
+From 6960b5053ed50202999b328adf27c3b0737db83e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:08:18 +0200
-Subject: [PATCH 214/303] Step 17.10: Styles for Navigation
+Subject: [PATCH 214/356] Step 17.10: Styles for Navigation
 
 ---
  imports/ui/components/navigation/navigation.less | 3 +++
@@ -7465,10 +7465,10 @@ index 0000000..4035b7b
 2.5.0
 
 
-From acf8efb2ec4efadc0d13faa9e4e5e35b296ef2ed Mon Sep 17 00:00:00 2001
+From 08a7d564af4af836d8d212c18049e912724d5569 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:08:50 +0200
-Subject: [PATCH 215/303] Step 17.11: Refactor PartiesList
+Subject: [PATCH 215/356] Step 17.11: Refactor PartiesList
 
 ---
  imports/ui/components/partiesList/partiesList.html | 94 ++++++++++++++--------
@@ -7581,10 +7581,10 @@ index a7984f6..29c4c69 100644
 2.5.0
 
 
-From de3285ee3a84f6b2f45062b460629d93f91478b1 Mon Sep 17 00:00:00 2001
+From 26e8dc045997392ce3588f6636ac4f404f5b41ba Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:09:21 +0200
-Subject: [PATCH 216/303] Step 17.12: Styles for PartiesList
+Subject: [PATCH 216/356] Step 17.12: Styles for PartiesList
 
 ---
  imports/ui/components/partiesList/partiesList.less | 30 ++++++++++++++++++++++
@@ -7631,10 +7631,10 @@ index 0000000..6cd14df
 2.5.0
 
 
-From 07c3a40e279aa9660ade54ab2d5501650ca26735 Mon Sep 17 00:00:00 2001
+From e6b72d3491084e963de970696a19d84da2a6c0e6 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:09:54 +0200
-Subject: [PATCH 217/303] Step 17.13: Refactor PartyAdd
+Subject: [PATCH 217/356] Step 17.13: Refactor PartyAdd
 
 ---
  imports/ui/components/partyAdd/partyAdd.html | 31 ++++++++++++++++------------
@@ -7682,10 +7682,10 @@ index 4db1888..7c4d284 100644
 2.5.0
 
 
-From 25604c7142347dab8f34b5ca27bfbc8b782988e0 Mon Sep 17 00:00:00 2001
+From 9743ab59861453d89bf767a9509cb71687c5a712 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:10:22 +0200
-Subject: [PATCH 218/303] Step 17.14: Styles for PartyAdd
+Subject: [PATCH 218/356] Step 17.14: Styles for PartyAdd
 
 ---
  imports/ui/components/partyAdd/partyAdd.less | 10 ++++++++++
@@ -7712,10 +7712,10 @@ index 0000000..90b24c1
 2.5.0
 
 
-From eeb42b8e75b7bf14518b4f63f7f479973edb522a Mon Sep 17 00:00:00 2001
+From 9f84f46b1720e67b4a25925b107983d14ec61bc9 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:11:05 +0200
-Subject: [PATCH 219/303] Step 17.15: Import PartyAdd
+Subject: [PATCH 219/356] Step 17.15: Import PartyAdd
 
 ---
  imports/ui/components/partiesList/partiesList.less | 2 ++
@@ -7735,10 +7735,10 @@ index 6cd14df..645d165 100644
 2.5.0
 
 
-From 756d829578a059a83f1402b7872d7b9c844cdd78 Mon Sep 17 00:00:00 2001
+From 2bbf616d3da4f8d7dda7b2cd1b7dba56727a6fec Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:11:45 +0200
-Subject: [PATCH 220/303] Step 17.16: Refactor PartiesMap
+Subject: [PATCH 220/356] Step 17.16: Refactor PartiesMap
 
 ---
  imports/ui/components/partiesMap/partiesMap.html | 3 +++
@@ -7759,10 +7759,10 @@ index a488738..870b2f7 100644
 2.5.0
 
 
-From 065891c29a10cfe79c55fe2a6135c97304588281 Mon Sep 17 00:00:00 2001
+From 2c2b41713f75b707e2f6c51baac09141277483f5 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:12:13 +0200
-Subject: [PATCH 221/303] Step 17.17: Styles for PartiesMap
+Subject: [PATCH 221/356] Step 17.17: Styles for PartiesMap
 
 ---
  imports/ui/components/partiesMap/partiesMap.less | 9 +++++++++
@@ -7788,10 +7788,10 @@ index 0000000..020e970
 2.5.0
 
 
-From f4f4942ab1e5b4042272bc445513a9cb6f15825e Mon Sep 17 00:00:00 2001
+From 2d9c9f51f51af6d4394adf9cccfc3d9be4bcb3ff Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:12:38 +0200
-Subject: [PATCH 222/303] Step 17.18: Import PartiesMap
+Subject: [PATCH 222/356] Step 17.18: Import PartiesMap
 
 ---
  imports/ui/components/partiesList/partiesList.less | 1 +
@@ -7810,10 +7810,10 @@ index 645d165..374d741 100644
 2.5.0
 
 
-From 8fd335643bb4a2846597bc5493649df3e8170aab Mon Sep 17 00:00:00 2001
+From 13973d9ba0b5e9453f1e8555ef1a47ceda67d6c5 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:13:05 +0200
-Subject: [PATCH 223/303] Step 17.19: Refactor PartiesSort
+Subject: [PATCH 223/356] Step 17.19: Refactor PartiesSort
 
 ---
  imports/ui/components/partiesSort/partiesSort.html | 10 ++++------
@@ -7838,10 +7838,10 @@ index cf2102b..b2a52b3 100644
 2.5.0
 
 
-From 27ce6b7d3c937e1b4706b2c7be4ce775e34d883f Mon Sep 17 00:00:00 2001
+From d3c1541b1455a50cec3677c34b3a062be636a351 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:13:38 +0200
-Subject: [PATCH 224/303] Step 17.20: Refactor PartyCreator
+Subject: [PATCH 224/356] Step 17.20: Refactor PartyCreator
 
 ---
  imports/ui/components/partyCreator/partyCreator.html | 2 +-
@@ -7862,10 +7862,10 @@ index de986fb..077739d 100644
 2.5.0
 
 
-From 5ae14d19e0fe60d2c37e6e3638a3418da9fc3904 Mon Sep 17 00:00:00 2001
+From 28fee9ddeaf57d220305c3922007049be57bb052 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:14:04 +0200
-Subject: [PATCH 225/303] Step 17.21: Styles for PartyCreator
+Subject: [PATCH 225/356] Step 17.21: Styles for PartyCreator
 
 ---
  imports/ui/components/partyCreator/partyCreator.less | 6 ++++++
@@ -7888,10 +7888,10 @@ index 0000000..4679f1f
 2.5.0
 
 
-From 95d893f19f46905e5b99c7b28fa224404c2e9e11 Mon Sep 17 00:00:00 2001
+From ba9cc32354a4cc1ce3d2cc15df5db62c8e7628f0 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:14:40 +0200
-Subject: [PATCH 226/303] Step 17.22: Import PartyCreator
+Subject: [PATCH 226/356] Step 17.22: Import PartyCreator
 
 ---
  imports/ui/components/partiesList/partiesList.less | 1 +
@@ -7910,10 +7910,10 @@ index 374d741..e73e928 100644
 2.5.0
 
 
-From f60af482611686be9a926e384554e6c31f9396d9 Mon Sep 17 00:00:00 2001
+From 5b8271b0d743ec9a59f141c8d229a300f458de9e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:15:08 +0200
-Subject: [PATCH 227/303] Step 17.23: Refactor PartyRemove
+Subject: [PATCH 227/356] Step 17.23: Refactor PartyRemove
 
 ---
  imports/ui/components/partyRemove/partyRemove.html | 2 +-
@@ -7930,10 +7930,10 @@ index 1295105..ebe46ea 100644
 2.5.0
 
 
-From acd221b515d36d0424ab9869da85714a9fe3502e Mon Sep 17 00:00:00 2001
+From cc7b236f59071140656135041c6980456834a744 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:15:48 +0200
-Subject: [PATCH 228/303] Step 17.24: Refactor PartyRsvp
+Subject: [PATCH 228/356] Step 17.24: Refactor PartyRsvp
 
 ---
  imports/ui/components/partyRsvp/partyRsvp.html | 6 +++---
@@ -7954,10 +7954,10 @@ index ca15260..e4c078c 100644
 2.5.0
 
 
-From 80814f55d159357a2b52e28a256729bd855c38ce Mon Sep 17 00:00:00 2001
+From 6f162864ba4a98c41650b0d580df8e28c203d4e6 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:16:13 +0200
-Subject: [PATCH 229/303] Step 17.25: Styles for PartyRsvp
+Subject: [PATCH 229/356] Step 17.25: Styles for PartyRsvp
 
 ---
  imports/ui/components/partyRsvp/partyRsvp.less | 4 ++++
@@ -7978,10 +7978,10 @@ index 0000000..be52d51
 2.5.0
 
 
-From 5bd1dd81cab601c7e84ccf583f8cb87b3681c2d0 Mon Sep 17 00:00:00 2001
+From de27ef659be74dbc10f6a18969a3fae6f4a29886 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:17:04 +0200
-Subject: [PATCH 230/303] Step 17.26: Import PartyRsvp
+Subject: [PATCH 230/356] Step 17.26: Import PartyRsvp
 
 ---
  imports/ui/components/partiesList/partiesList.less | 1 +
@@ -8000,10 +8000,10 @@ index e73e928..be384ba 100644
 2.5.0
 
 
-From 824d7bcf3fe55f3fa9bc7fd1b8c717953850a5d1 Mon Sep 17 00:00:00 2001
+From ee3a06a96bef54a9804099cd702b4d9c28cdef5b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:17:32 +0200
-Subject: [PATCH 231/303] Step 17.27: Refactor PartyRsvpsList
+Subject: [PATCH 231/356] Step 17.27: Refactor PartyRsvpsList
 
 ---
  .../components/partyRsvpsList/partyRsvpsList.html  | 36 ++++++++++++++++------
@@ -8054,10 +8054,10 @@ index 2e1749d..5c24b02 100644
 2.5.0
 
 
-From 74f9c366f56ce71ef59b8b249af6b66fa7cdaeb0 Mon Sep 17 00:00:00 2001
+From fdb177481197456cb8a5395a21ea1d8d9a8cd9ff Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:17:59 +0200
-Subject: [PATCH 232/303] Step 17.28: Styles for PartyRsvpsList
+Subject: [PATCH 232/356] Step 17.28: Styles for PartyRsvpsList
 
 ---
  .../components/partyRsvpsList/partyRsvpsList.less  | 24 ++++++++++++++++++++++
@@ -8098,10 +8098,10 @@ index 0000000..ca24446
 2.5.0
 
 
-From 109e0db28594996bd8d375f346638c82f61c78d3 Mon Sep 17 00:00:00 2001
+From 761079e6f2b53848b141f6c72be879b1879296ce Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:18:30 +0200
-Subject: [PATCH 233/303] Step 17.29: Import PartyRsvpsList
+Subject: [PATCH 233/356] Step 17.29: Import PartyRsvpsList
 
 ---
  imports/ui/components/partiesList/partiesList.less | 1 +
@@ -8120,10 +8120,10 @@ index be384ba..a1eac5c 100644
 2.5.0
 
 
-From 3ebe2feb543e7bb99ff531f5715a523ab120c75b Mon Sep 17 00:00:00 2001
+From c9ac77bf2b37f7eff28b3413db1c90401ff85f11 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:19:03 +0200
-Subject: [PATCH 234/303] Step 17.30: Refactor PartyUninvited
+Subject: [PATCH 234/356] Step 17.30: Refactor PartyUninvited
 
 ---
  imports/ui/components/partyUninvited/partyUninvited.html | 12 ++++++------
@@ -8154,10 +8154,10 @@ index 86d2519..e9f9e1c 100644
 2.5.0
 
 
-From 13ea9ab2a9ea0d72fe28d5ae266498ef8c828666 Mon Sep 17 00:00:00 2001
+From d8a966de799806dc61f15a95ad296a04316ca140 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:26:22 +0200
-Subject: [PATCH 235/303] Step 17.31: Styles for PartyUninvited
+Subject: [PATCH 235/356] Step 17.31: Styles for PartyUninvited
 
 ---
  imports/ui/components/partyUninvited/partyUninvited.less | 8 ++++++++
@@ -8182,10 +8182,10 @@ index 0000000..52b27fe
 2.5.0
 
 
-From 208cd2cf199ce7d51f6c1cddc388b55474a52ef6 Mon Sep 17 00:00:00 2001
+From f3ee03e6b2362803efc46e2e27f511867cfcbd01 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:19:41 +0200
-Subject: [PATCH 236/303] Step 17.32: Refactor PartyDetails
+Subject: [PATCH 236/356] Step 17.32: Refactor PartyDetails
 
 ---
  .../ui/components/partyDetails/partyDetails.html   | 42 ++++++++++++++++------
@@ -8245,10 +8245,10 @@ index 7354dd6..4023174 100644
 2.5.0
 
 
-From 733ab7d26c1bc1f4cb658aade2e328365fd7ebed Mon Sep 17 00:00:00 2001
+From 5438662929227f82e692f18c9767b0d66ac74096 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:20:17 +0200
-Subject: [PATCH 237/303] Step 17.33: Styles for PartyDetails
+Subject: [PATCH 237/356] Step 17.33: Styles for PartyDetails
 
 ---
  imports/ui/components/partyDetails/partyDetails.less | 9 +++++++++
@@ -8274,10 +8274,10 @@ index 0000000..bfea863
 2.5.0
 
 
-From 98b9e62cc19f7b83d12c2b7fb79e68321c637e13 Mon Sep 17 00:00:00 2001
+From b8ebabbd3d57ba8e82bf385d9dcd0a22a95b2302 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:21:01 +0200
-Subject: [PATCH 238/303] Step 17.34: Styles for PartyMap
+Subject: [PATCH 238/356] Step 17.34: Styles for PartyMap
 
 ---
  imports/ui/components/partyMap/partyMap.less | 10 ++++++++++
@@ -8304,10 +8304,10 @@ index 0000000..3b4bed1
 2.5.0
 
 
-From ac7be9f8ef1030e1d350373922483b10c2f32eab Mon Sep 17 00:00:00 2001
+From d7f4c7c5773f6fd5aa7d2b53e528a6e2a9b8da00 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:21:22 +0200
-Subject: [PATCH 239/303] Step 17.35: Remove old css
+Subject: [PATCH 239/356] Step 17.35: Remove old css
 
 ---
  imports/ui/components/partyMap/partyMap.js | 1 -
@@ -8329,10 +8329,10 @@ index 5fe2dfa..9257efe 100644
 2.5.0
 
 
-From 3e6f69a28cf1d2848b13b5f34d43137a239e93c1 Mon Sep 17 00:00:00 2001
+From b54988638c3febbd3af8e41e5ea1e07bfe2a4e61 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:21:43 +0200
-Subject: [PATCH 240/303] Step 17.36: Delete old file
+Subject: [PATCH 240/356] Step 17.36: Delete old file
 
 ---
  imports/ui/components/partyMap/partyMap.css | 4 ----
@@ -8353,10 +8353,10 @@ index f4b49f5..0000000
 2.5.0
 
 
-From b50555220d50ff0064a4f4109057298b493711fe Mon Sep 17 00:00:00 2001
+From 7bae702301cfdcc01bb7ef68e8b446c9289846b4 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:22:35 +0200
-Subject: [PATCH 241/303] Step 17.37: Import PartyMap
+Subject: [PATCH 241/356] Step 17.37: Import PartyMap
 
 ---
  imports/ui/components/partyDetails/partyDetails.less | 1 +
@@ -8375,10 +8375,10 @@ index bfea863..a42c467 100644
 2.5.0
 
 
-From 1f9baa863f9e003570820a564e2d11e0fb400a23 Mon Sep 17 00:00:00 2001
+From 74be84ff28ab914bad6dd87f82eff4ae2c2a59d4 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:23:50 +0200
-Subject: [PATCH 242/303] Step 17.38: Import missing files
+Subject: [PATCH 242/356] Step 17.38: Import missing files
 
 ---
  imports/ui/components/socially/socially.less | 5 +++++
@@ -8401,10 +8401,10 @@ index eec0480..3eabc12 100644
 2.5.0
 
 
-From 06c079908f82dc2fe825cbfa3f733913af7f72e0 Mon Sep 17 00:00:00 2001
+From 38602e67d6a8aa199156f66931c8d18cec2d0481 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 01:32:24 +0200
-Subject: [PATCH 243/303] Step 17.39: Add checking methods
+Subject: [PATCH 243/356] Step 17.39: Add checking methods
 
 ---
  imports/ui/components/partyRsvp/partyRsvp.js | 18 ++++++++++++++++++
@@ -8464,10 +8464,10 @@ index e5907b2..6c29c65 100644
 2.5.0
 
 
-From 6ac4549a61c1b9395a9ae94f1458b41b3d0d9fb5 Mon Sep 17 00:00:00 2001
+From bb64df1bedbc09a6b7a4000d6b8848cee86b47cf Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:26:23 +0200
-Subject: [PATCH 244/303] Step 17.40: Remove unused partyRsvpUsers
+Subject: [PATCH 244/356] Step 17.40: Remove unused partyRsvpUsers
 
 ---
  .../components/partyRsvpUsers/partyRsvpUsers.html  |  5 ----
@@ -8526,10 +8526,10 @@ index f94eb18..0000000
 2.5.0
 
 
-From c0eddc65d0fc0ee86ab2a694071c5acb60be8bcd Mon Sep 17 00:00:00 2001
+From 7e717a577e5ce232f76f8a6bbce31f39708988d6 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:26:40 +0200
-Subject: [PATCH 245/303] Step 17.41: Remove unused partyUnanswered
+Subject: [PATCH 245/356] Step 17.41: Remove unused partyUnanswered
 
 ---
  .../partyUnanswered/partyUnanswered.html           |  5 ---
@@ -8598,10 +8598,10 @@ index d6eaf46..0000000
 2.5.0
 
 
-From 85679913dcdbee84d9068f9ffebf166724fec35c Mon Sep 17 00:00:00 2001
+From b74bd4de61ea1c4579a14c453e8146d29bf5c4b2 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:27:20 +0200
-Subject: [PATCH 246/303] Step 17.42: Remove PartyUnanswered
+Subject: [PATCH 246/356] Step 17.42: Remove PartyUnanswered
 
 ---
  imports/ui/components/partiesList/partiesList.js | 4 +---
@@ -8633,10 +8633,10 @@ index 9a1811b..de14546 100644
 2.5.0
 
 
-From 8d61420a3585addb5aa54895db1f11d55d69fdb8 Mon Sep 17 00:00:00 2001
+From b3b2706d143c1dd385480453930f6f9fabf32517 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:27:38 +0200
-Subject: [PATCH 247/303] Step 17.43: Remove PartyRsvpUsers
+Subject: [PATCH 247/356] Step 17.43: Remove PartyRsvpUsers
 
 ---
  imports/ui/components/partyRsvpsList/partyRsvpsList.js | 4 +---
@@ -8668,24 +8668,24 @@ index 1150a47..4e6e752 100644
 2.5.0
 
 
-From 63b3e203bec5f1021c7a310c2cd8321695d43ad2 Mon Sep 17 00:00:00 2001
+From 21ca9fdfdad7770e02caecf21b85162d1721eb05 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:37:40 +0200
-Subject: [PATCH 248/303] Step 18.1: Uninstall `bootstrap`
+Subject: [PATCH 248/356] Step 18.1: Uninstall `bootstrap`
 
 ---
  package.json | 1 -
  1 file changed, 1 deletion(-)
 
 diff --git a/package.json b/package.json
-index 0b41357..1bb773a 100644
+index 9f874c7..1bb773a 100644
 --- a/package.json
 +++ b/package.json
 @@ -12,7 +12,6 @@
      "angular-simple-logger": "^0.1.7",
      "angular-ui-router": "^1.0.0-alpha.4",
      "angular-utils-pagination": "^0.11.1",
--    "bootstrap4-webpack-package": "^1.0.0",
+-    "bootstrap": "^4.0.0-alpha.2",
      "meteor-node-stubs": "~0.2.0",
      "underscore": "^1.8.3"
    },
@@ -8693,10 +8693,10 @@ index 0b41357..1bb773a 100644
 2.5.0
 
 
-From f0e0f4ac8c19badd53cb6c185cd980e27879507e Mon Sep 17 00:00:00 2001
+From 6639ba9605adf4c6daa3cd76b298a429157bf41e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:38:13 +0200
-Subject: [PATCH 249/303] Step 18.2: Install `angular-material`
+Subject: [PATCH 249/356] Step 18.2: Install `angular-material`
 
 ---
  package.json | 4 ++++
@@ -8722,10 +8722,10 @@ index 1bb773a..4e726a8 100644
 2.5.0
 
 
-From f59d79af98ef93ba1b1998f7c4ba6fc0ce72e2ec Mon Sep 17 00:00:00 2001
+From b91219cd33ab15514111c4303009f1158fc9ca90 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:38:56 +0200
-Subject: [PATCH 250/303] Step 18.3: Add css
+Subject: [PATCH 250/356] Step 18.3: Add css
 
 ---
  client/index.html | 2 +-
@@ -8748,22 +8748,22 @@ index d4505ca..4a914a1 100644
 2.5.0
 
 
-From 701032d5c16695fdfcc5859ed05434ab8c192adf Mon Sep 17 00:00:00 2001
+From e80929fe612c352a8ae852cb21711531421b80ab Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:31:01 +0200
-Subject: [PATCH 251/303] Step 18.4: Remove bootstrap from main.js
+Subject: [PATCH 251/356] Step 18.4: Remove bootstrap from main.js
 
 ---
  client/main.js | 1 -
  1 file changed, 1 deletion(-)
 
 diff --git a/client/main.js b/client/main.js
-index a1d63f6..06731e1 100644
+index 52cb827..06731e1 100644
 --- a/client/main.js
 +++ b/client/main.js
 @@ -1,5 +1,4 @@
  import angular from 'angular';
--import 'bootstrap4-webpack-package';
+-import 'bootstrap/dist/css/bootstrap.css';
  
  import { Meteor } from 'meteor/meteor';
  
@@ -8771,10 +8771,10 @@ index a1d63f6..06731e1 100644
 2.5.0
 
 
-From 06d1c7cb28eb5d3251b044b5332fc5f1fabb5e83 Mon Sep 17 00:00:00 2001
+From 2bb35e3371c4443cfb4e554d950320ae0e0b1a7f Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:39:53 +0200
-Subject: [PATCH 252/303] Step 18.5: Add ngMaterial to Socially
+Subject: [PATCH 252/356] Step 18.5: Add ngMaterial to Socially
 
 ---
  imports/ui/components/socially/socially.js | 4 +++-
@@ -8812,10 +8812,10 @@ index 61c86d1..d6d7329 100644
 2.5.0
 
 
-From 4c1a551f227d93c33af1991fe8275e5d925087c4 Mon Sep 17 00:00:00 2001
+From 9e85ca892f8b4a8269a957d5f88848ce9c8e414e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:41:34 +0200
-Subject: [PATCH 253/303] Step 18.6: Clean up Socially template
+Subject: [PATCH 253/356] Step 18.6: Clean up Socially template
 
 ---
  imports/ui/components/socially/socially.html | 4 ++--
@@ -8835,10 +8835,10 @@ index 2e91050..7fdb2de 100644
 2.5.0
 
 
-From 3b3bdef673064db08af940f7c9e2dab2c549e43d Mon Sep 17 00:00:00 2001
+From d56f33c6a84b44d2a546add0022b855bc9d6e5a1 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:43:06 +0200
-Subject: [PATCH 254/303] Step 18.7: Refactor Navigation
+Subject: [PATCH 254/356] Step 18.7: Refactor Navigation
 
 ---
  imports/ui/components/navigation/navigation.html | 14 +++++++++-----
@@ -8868,10 +8868,10 @@ index 2bcae64..0b1d8a6 100644
 2.5.0
 
 
-From 590c28916e14350a9ab643925aa3a2f47b36f646 Mon Sep 17 00:00:00 2001
+From 989e9b0d9f0fafff05a359e2ae4cbbfbfe9abbac Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:43:40 +0200
-Subject: [PATCH 255/303] Step 18.8: Add space before loginButtons
+Subject: [PATCH 255/356] Step 18.8: Add space before loginButtons
 
 ---
  imports/ui/components/navigation/navigation.less | 4 +++-
@@ -8892,10 +8892,10 @@ index 4035b7b..87b8777 100644
 2.5.0
 
 
-From e749eb736ce9d4309b38dc0aa630efb395a1c786 Mon Sep 17 00:00:00 2001
+From b0582767be63826b0fddd818a3f2a9396a2232be Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:44:33 +0200
-Subject: [PATCH 256/303] Step 18.9: Refactor PartiesList
+Subject: [PATCH 256/356] Step 18.9: Refactor PartiesList
 
 ---
  imports/ui/components/partiesList/partiesList.html | 99 ++++++++++------------
@@ -9019,10 +9019,10 @@ index 29c4c69..b6772eb 100644
 2.5.0
 
 
-From 9f8fad767744324b63a7f7d5d116e84abb7903d9 Mon Sep 17 00:00:00 2001
+From 4f87f82dd9e387caaec6dd83cd36a6c78e815abf Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:45:55 +0200
-Subject: [PATCH 257/303] Step 18.10: Leave only one definition
+Subject: [PATCH 257/356] Step 18.10: Leave only one definition
 
 ---
  imports/ui/components/partiesList/partiesList.less | 35 ++--------------------
@@ -9075,10 +9075,10 @@ index a1eac5c..ba0839b 100644
 2.5.0
 
 
-From 6b309bfe9a0f24453d54cd1e43ed1cbf38e12beb Mon Sep 17 00:00:00 2001
+From 3046ed1772f65af73e64e0d9f342542e0ff3a31e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:46:45 +0200
-Subject: [PATCH 258/303] Step 18.11: Refactor PartiesMap
+Subject: [PATCH 258/356] Step 18.11: Refactor PartiesMap
 
 ---
  imports/ui/components/partiesMap/partiesMap.html | 3 ---
@@ -9099,10 +9099,10 @@ index 870b2f7..a488738 100644
 2.5.0
 
 
-From c8b27c08cc684ba26e841f5d11c583dcb7d4077e Mon Sep 17 00:00:00 2001
+From 8c66ecf6f302369add7ac8d3474c4d1a08e768dd Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:47:31 +0200
-Subject: [PATCH 259/303] Step 18.12: Styles for PartiesMap
+Subject: [PATCH 259/356] Step 18.12: Styles for PartiesMap
 
 ---
  imports/ui/components/partiesMap/partiesMap.less | 2 +-
@@ -9124,10 +9124,10 @@ index 020e970..b69b834 100644
 2.5.0
 
 
-From 1c5aa9e9279c65a94ceaa065c7fb1f7c4b56bcb7 Mon Sep 17 00:00:00 2001
+From 886dfb6db7339f01031fb4690c9c427a3de5289b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:13:36 +0200
-Subject: [PATCH 260/303] Step 18.13: Import in PartiesList
+Subject: [PATCH 260/356] Step 18.13: Import in PartiesList
 
 ---
  imports/ui/components/partiesList/partiesList.less | 2 ++
@@ -9147,10 +9147,10 @@ index ba0839b..d3f7da4 100644
 2.5.0
 
 
-From 955ecd72439ed371437f49a9a0a5876b67458307 Mon Sep 17 00:00:00 2001
+From b2eaf309a23e388b16433d92e4e0b53ef8fddc18 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:48:05 +0200
-Subject: [PATCH 261/303] Step 18.14: Refactor PartiesSort
+Subject: [PATCH 261/356] Step 18.14: Refactor PartiesSort
 
 ---
  imports/ui/components/partiesSort/partiesSort.html | 14 ++++++++++----
@@ -9179,10 +9179,10 @@ index b2a52b3..0b7a94e 100644
 2.5.0
 
 
-From d4c567f49fb8aa4bb7f13c6ecd92f7abb4895484 Mon Sep 17 00:00:00 2001
+From e2dbb382f0e0b9b3f125115ac638b231a8ddbbc6 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:48:41 +0200
-Subject: [PATCH 262/303] Step 18.15: Refactor PartyAdd
+Subject: [PATCH 262/356] Step 18.15: Refactor PartyAdd
 
 ---
  imports/ui/components/partyAdd/partyAdd.html | 26 ++++++++++++++------------
@@ -9231,10 +9231,10 @@ index 7c4d284..6e504f0 100644
 2.5.0
 
 
-From 076cf10ef6f228336500bb78cdf39a4b99339450 Mon Sep 17 00:00:00 2001
+From 5ebb22ad5706636e549378aa2c6218d3da220340 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:49:18 +0200
-Subject: [PATCH 263/303] Step 18.16: Remove styles for PartyAdd
+Subject: [PATCH 263/356] Step 18.16: Remove styles for PartyAdd
 
 ---
  imports/ui/components/partyAdd/partyAdd.less | 10 ----------
@@ -9261,10 +9261,10 @@ index 90b24c1..0000000
 2.5.0
 
 
-From 732e4323f2140697748ae93fa96304a1753ccb3d Mon Sep 17 00:00:00 2001
+From 061ae17f28806b9f6eb5ba29120af885cfc3983a Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:50:00 +0200
-Subject: [PATCH 264/303] Step 18.17: Refactor PartyCreator
+Subject: [PATCH 264/356] Step 18.17: Refactor PartyCreator
 
 ---
  imports/ui/components/partyCreator/partyCreator.html | 2 +-
@@ -9285,10 +9285,10 @@ index 077739d..de986fb 100644
 2.5.0
 
 
-From 0cbfbd4ea9fd5db0c74969da7a6f3a2bea9f2e22 Mon Sep 17 00:00:00 2001
+From 5abc35e512422a0bcfb6b291e2e1dab71732231b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 02:50:35 +0200
-Subject: [PATCH 265/303] Step 18.18: Remove partyCreator.less
+Subject: [PATCH 265/356] Step 18.18: Remove partyCreator.less
 
 ---
  imports/ui/components/partyCreator/partyCreator.less | 6 ------
@@ -9311,10 +9311,10 @@ index 4679f1f..0000000
 2.5.0
 
 
-From 256b2cf9c8f95c122b7589f2c73cc56f13f4be82 Mon Sep 17 00:00:00 2001
+From 4f508e4a90eba86d6eba13e2f277badb1b226dc6 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:08:43 +0200
-Subject: [PATCH 266/303] Step 18.19: Add `material-design-icons`
+Subject: [PATCH 266/356] Step 18.19: Add `material-design-icons`
 
 ---
  .meteor/packages | 1 +
@@ -9331,24 +9331,24 @@ index 1b86693..c6567f3 100644
  less
 +planettraining:material-design-icons
 diff --git a/.meteor/versions b/.meteor/versions
-index b44d0e4..4f70e6c 100644
+index 7995fa7..fb2822c 100644
 --- a/.meteor/versions
 +++ b/.meteor/versions
 @@ -67,9 +67,9 @@ oauth2@1.1.7
- observe-sequence@1.0.9
- ordered-dict@1.0.5
+ observe-sequence@1.0.11
+ ordered-dict@1.0.7
  pbastowski:angular-babel@1.3.2
 +planettraining:material-design-icons@2.2.0
- promise@0.6.5
- random@1.0.7
+ promise@0.6.7
+ random@1.0.9
 -reactive-dict@1.1.5
  rate-limit@1.0.2
  reactive-dict@1.1.5
- reactive-var@1.0.7
-@@ -77,7 +77,6 @@ reload@1.1.6
- retry@1.0.5
- routepolicy@1.0.8
- sanjo:jasmine@1.0.0
+ reactive-var@1.0.9
+@@ -77,7 +77,6 @@ reload@1.1.8
+ retry@1.0.7
+ routepolicy@1.0.10
+ sanjo:jasmine@1.0.1
 -session@1.1.3
  service-configuration@1.0.7
  session@1.1.3
@@ -9357,10 +9357,10 @@ index b44d0e4..4f70e6c 100644
 2.5.0
 
 
-From c19107f7a71935c4adf6f5526e99bc60e24a1f32 Mon Sep 17 00:00:00 2001
+From 47b96c586cf577ab0a04a4a2ce04569b85c21329 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:10:01 +0200
-Subject: [PATCH 267/303] Step 18.20: Set icons
+Subject: [PATCH 267/356] Step 18.20: Set icons
 
 ---
  imports/ui/components/socially/socially.js | 20 +++++++++++++++++++-
@@ -9406,10 +9406,10 @@ index d6d7329..4cd8e0c 100644
 2.5.0
 
 
-From 1783faba0593f4729ca1299dfb43a5959ad65f81 Mon Sep 17 00:00:00 2001
+From 814e736a09f00ad2bf850f85e50928ae23696a79 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:10:41 +0200
-Subject: [PATCH 268/303] Step 18.21: Refactor PartyRemove
+Subject: [PATCH 268/356] Step 18.21: Refactor PartyRemove
 
 ---
  imports/ui/components/partyRemove/partyRemove.html | 2 +-
@@ -9426,10 +9426,10 @@ index ebe46ea..fc1206c 100644
 2.5.0
 
 
-From 8665fcf79354d8f9a74a7b4c7e19b87bf4d771b4 Mon Sep 17 00:00:00 2001
+From 267db0d16f8cca6756d8bbd127d2396818795ce7 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:11:20 +0200
-Subject: [PATCH 269/303] Step 18.22: Styles for PartyRemove
+Subject: [PATCH 269/356] Step 18.22: Styles for PartyRemove
 
 ---
  imports/ui/components/partyRemove/partyRemove.less | 3 +++
@@ -9449,10 +9449,10 @@ index 0000000..d7ad1f1
 2.5.0
 
 
-From b8ccc6bf897b559cba727c492aa11b960d5dd513 Mon Sep 17 00:00:00 2001
+From 8f73501ef868a7bbad3452e6e57e137b8ddefe23 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:12:08 +0200
-Subject: [PATCH 270/303] Step 18.23: Import to PartiesList
+Subject: [PATCH 270/356] Step 18.23: Import to PartiesList
 
 ---
  imports/ui/components/partiesList/partiesList.less | 1 +
@@ -9471,10 +9471,10 @@ index d3f7da4..26a3d6b 100644
 2.5.0
 
 
-From 4b772ed8098357be2d6f178cae7a28c3e6ae510d Mon Sep 17 00:00:00 2001
+From 63bfafafb1b966860f580259e9f5ea7a65bc0e1b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:17:34 +0200
-Subject: [PATCH 271/303] Step 18.24: Refactor PartyRsvp
+Subject: [PATCH 271/356] Step 18.24: Refactor PartyRsvp
 
 ---
  imports/ui/components/partyRsvp/partyRsvp.html | 8 +++++---
@@ -9497,10 +9497,10 @@ index e4c078c..ec6302b 100644
 2.5.0
 
 
-From 547cb5f2c27829e27b898f4cb021b33781c32472 Mon Sep 17 00:00:00 2001
+From c775e3d576ee75c415a992833d466f46d950ea67 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:18:08 +0200
-Subject: [PATCH 272/303] Step 18.25: Remove styles
+Subject: [PATCH 272/356] Step 18.25: Remove styles
 
 ---
  imports/ui/components/partyRsvp/partyRsvp.less | 4 ----
@@ -9521,10 +9521,10 @@ index be52d51..0000000
 2.5.0
 
 
-From aeefd7311071a63658c17d48e7a2acc670d22a38 Mon Sep 17 00:00:00 2001
+From 8f3d7ec6516a8daf48e174f180817b0c4b58057b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:19:01 +0200
-Subject: [PATCH 273/303] Step 18.26: Refactor PartyUninvited
+Subject: [PATCH 273/356] Step 18.26: Refactor PartyUninvited
 
 ---
  .../components/partyUninvited/partyUninvited.html  | 22 ++++++++++++----------
@@ -9561,10 +9561,10 @@ index e9f9e1c..84b3eaf 100644
 2.5.0
 
 
-From 83dd1ea12c657b0b1081507f026a4234a114e340 Mon Sep 17 00:00:00 2001
+From cf092240bfabd01528b8e8b518c4746398ae1b9b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:19:24 +0200
-Subject: [PATCH 274/303] Step 18.27: Remove unused styles
+Subject: [PATCH 274/356] Step 18.27: Remove unused styles
 
 ---
  imports/ui/components/partyUninvited/partyUninvited.less | 8 --------
@@ -9589,10 +9589,10 @@ index 52b27fe..0000000
 2.5.0
 
 
-From 56b3b87fc4018d5196009fe7273a6574a2ba43f0 Mon Sep 17 00:00:00 2001
+From a53f3fce894e13c7fa2a9e30125f669f3c46bdcd Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:20:28 +0200
-Subject: [PATCH 275/303] Step 18.28: Add PartyRsvpsList less to PartiesList
+Subject: [PATCH 275/356] Step 18.28: Add PartyRsvpsList less to PartiesList
 
 ---
  imports/ui/components/partiesList/partiesList.less | 1 +
@@ -9611,10 +9611,10 @@ index 26a3d6b..6ac87dc 100644
 2.5.0
 
 
-From 820e84b79189af485dcf4b97dd449564599a6493 Mon Sep 17 00:00:00 2001
+From 67af7d5a3aa7910110f8db01d35c8279239ac094 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:21:23 +0200
-Subject: [PATCH 276/303] Step 18.29: Update styles of PartyMap
+Subject: [PATCH 276/356] Step 18.29: Update styles of PartyMap
 
 ---
  imports/ui/components/partyMap/partyMap.less | 3 +--
@@ -9637,10 +9637,10 @@ index 3b4bed1..62f1643 100644
 2.5.0
 
 
-From 6a63a1fa78866d06a1ab5bef7249a9532e24bce0 Mon Sep 17 00:00:00 2001
+From 0f109191fa8d9088df1afe3474eb83ee70bfb4ad Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:23:22 +0200
-Subject: [PATCH 277/303] Step 18.30: Refactor PartyDetails
+Subject: [PATCH 277/356] Step 18.30: Refactor PartyDetails
 
 ---
  .../ui/components/partyDetails/partyDetails.html   | 51 ++++++++++------------
@@ -9712,10 +9712,10 @@ index 4023174..59fe896 100644
 2.5.0
 
 
-From 9c862797966fe081d72256747372fa92a0d623bc Mon Sep 17 00:00:00 2001
+From 96e105fc760305bbb7bd83c1ba116abe148e89cd Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:24:01 +0200
-Subject: [PATCH 278/303] Step 18.31: Leave only PartyMap inside PartyDetails
+Subject: [PATCH 278/356] Step 18.31: Leave only PartyMap inside PartyDetails
  less
 
 ---
@@ -9741,10 +9741,10 @@ index a42c467..bb42a69 100644
 2.5.0
 
 
-From eb039d5ab9b9a59c11f483d5c53cbde067e535d3 Mon Sep 17 00:00:00 2001
+From 6c2c7b4e6a9c672ed8b7738ef8c4164b796d60b8 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Wed, 13 Apr 2016 11:43:44 +0200
-Subject: [PATCH 279/303] Step 18.32: Create view for PartyAddButton
+Subject: [PATCH 279/356] Step 18.32: Create view for PartyAddButton
 
 ---
  imports/ui/components/partyAddButton/partyAddButton.html | 3 +++
@@ -9764,10 +9764,10 @@ index 0000000..6e37857
 2.5.0
 
 
-From cc4c1a51e086f80044bb821f3f0bd4ae8868199d Mon Sep 17 00:00:00 2001
+From ee115a3a980c007daf8d61535f2dde8535c8423b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Wed, 13 Apr 2016 11:45:15 +0200
-Subject: [PATCH 280/303] Step 18.33: Create PartyAddButton component
+Subject: [PATCH 280/356] Step 18.33: Create PartyAddButton component
 
 ---
  .../ui/components/partyAddButton/partyAddButton.js | 45 ++++++++++++++++++++++
@@ -9829,10 +9829,10 @@ index 0000000..e661ba5
 2.5.0
 
 
-From 2bf36d20ffbe37f10c603c9b918f8e508b2b02b0 Mon Sep 17 00:00:00 2001
+From 35826848360589b05a7945be7cb59fe151a665ff Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Wed, 13 Apr 2016 11:46:03 +0200
-Subject: [PATCH 281/303] Step 18.34: Add view for modal window
+Subject: [PATCH 281/356] Step 18.34: Add view for modal window
 
 ---
  imports/ui/components/partyAddButton/partyAddModal.html | 16 ++++++++++++++++
@@ -9865,10 +9865,10 @@ index 0000000..3b490ec
 2.5.0
 
 
-From dff026001715533b40f461db616530b41b61a638 Mon Sep 17 00:00:00 2001
+From 67d51d5adceff26ab5888e7a050935685545aa33 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Wed, 13 Apr 2016 11:46:27 +0200
-Subject: [PATCH 282/303] Step 18.35: Add some style
+Subject: [PATCH 282/356] Step 18.35: Add some style
 
 ---
  imports/ui/components/partyAddButton/partyAddButton.less | 7 +++++++
@@ -9892,10 +9892,10 @@ index 0000000..73828f6
 2.5.0
 
 
-From 3262190e7070d18d535df972964b8b4188831d10 Mon Sep 17 00:00:00 2001
+From a6f94d75714f281d3abd10a19ab820cf1e2eb5fe Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Wed, 13 Apr 2016 11:47:55 +0200
-Subject: [PATCH 283/303] Step 18.36: Implement `done` expression to PartyAdd
+Subject: [PATCH 283/356] Step 18.36: Implement `done` expression to PartyAdd
 
 ---
  imports/ui/components/partyAdd/partyAdd.js | 8 ++++++++
@@ -9931,10 +9931,10 @@ index 5b1ead3..0b1d240 100644
 2.5.0
 
 
-From ae0c966dae43c83bb5e7f8ad0b5d2c01fe37fd16 Mon Sep 17 00:00:00 2001
+From 8b74839520b7ae8cb8feda2319967b852e32349e Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Wed, 13 Apr 2016 11:48:44 +0200
-Subject: [PATCH 284/303] Step 18.37: Add PartyAddButton to PartiesList
+Subject: [PATCH 284/356] Step 18.37: Add PartyAddButton to PartiesList
 
 ---
  imports/ui/components/partiesList/partiesList.js | 4 ++--
@@ -9966,10 +9966,10 @@ index de14546..92f56d3 100644
 2.5.0
 
 
-From 637b10e4e6dc2705733879b6047b6f19430ed658 Mon Sep 17 00:00:00 2001
+From c43bd1a5bfd7f5de2c9cef2488eb0dd45b4ab360 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Wed, 13 Apr 2016 11:51:45 +0200
-Subject: [PATCH 285/303] Step 18.38: Implement PartyAddButton
+Subject: [PATCH 285/356] Step 18.38: Implement PartyAddButton
 
 ---
  imports/ui/components/partiesList/partiesList.html | 5 +----
@@ -9993,10 +9993,10 @@ index b6772eb..12987b3 100644
 2.5.0
 
 
-From 50e28c7b715c023aed3351d054003c25168752c7 Mon Sep 17 00:00:00 2001
+From f61ee2c1153f36b3e85d6a05444ae6ff09058052 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Wed, 13 Apr 2016 11:51:59 +0200
-Subject: [PATCH 286/303] Step 18.39: Import styles
+Subject: [PATCH 286/356] Step 18.39: Import styles
 
 ---
  imports/ui/components/partiesList/partiesList.less | 1 +
@@ -10016,10 +10016,10 @@ index 6ac87dc..b0bc5dc 100644
 2.5.0
 
 
-From c36ac1e256284242e738b0deeaf37dd07e997550 Mon Sep 17 00:00:00 2001
+From 837ea3f3e5d1bb5a2a3ac462b50d7835269a14da Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:25:09 +0200
-Subject: [PATCH 287/303] Step 18.40: Create view for Auth
+Subject: [PATCH 287/356] Step 18.40: Create view for Auth
 
 ---
  imports/ui/components/auth/auth.html | 6 ++++++
@@ -10042,10 +10042,10 @@ index 0000000..28f7a45
 2.5.0
 
 
-From e8de45d2bcfc47b7e8ebd327a6728dbc00736e2b Mon Sep 17 00:00:00 2001
+From 506d57a70b870988d0718c22079c02e5a4537906 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:25:49 +0200
-Subject: [PATCH 288/303] Step 18.41: Create Auth component
+Subject: [PATCH 288/356] Step 18.41: Create Auth component
 
 ---
  imports/ui/components/auth/auth.js | 41 ++++++++++++++++++++++++++++++++++++++
@@ -10103,10 +10103,10 @@ index 0000000..724bdbe
 2.5.0
 
 
-From 7c4a6d747307b73a4c8de9710f0394f8023e56dc Mon Sep 17 00:00:00 2001
+From 6e4609eb50ccb50cbf668c33ab47f0d62a92e02b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:42:53 +0200
-Subject: [PATCH 289/303] Step 18.42: View for Login
+Subject: [PATCH 289/356] Step 18.42: View for Login
 
 ---
  imports/ui/components/login/login.html | 72 ++++++++++++++++++++++++++++++++++
@@ -10195,10 +10195,10 @@ index 0000000..64ea544
 2.5.0
 
 
-From 46b64c3bbc4b82d81055d02d00fc9e0f0af08f72 Mon Sep 17 00:00:00 2001
+From 6f325fc270fc422fbdd6b3a0da1f85ac913e4d3b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:44:02 +0200
-Subject: [PATCH 290/303] Step 18.43: Create Login
+Subject: [PATCH 290/356] Step 18.43: Create Login
 
 ---
  imports/ui/components/login/login.js | 61 ++++++++++++++++++++++++++++++++++++
@@ -10276,10 +10276,10 @@ index 0000000..f5a3be4
 2.5.0
 
 
-From 354d3f609827a1866a51cc18ea55da1cfa488b1f Mon Sep 17 00:00:00 2001
+From 39075ace26ccc2904ab418d926032bdb9d87ae9f Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:44:39 +0200
-Subject: [PATCH 291/303] Step 18.44: Add Login to Auth
+Subject: [PATCH 291/356] Step 18.44: Add Login to Auth
 
 ---
  imports/ui/components/auth/auth.js | 4 +++-
@@ -10311,10 +10311,10 @@ index 724bdbe..9c5de5a 100644
 2.5.0
 
 
-From 586858677486125e6df7e226cbad4c06424053ff Mon Sep 17 00:00:00 2001
+From 6c770bfa067356f36e83108b54402a2549ca890b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:45:38 +0200
-Subject: [PATCH 292/303] Step 18.45: View for Register
+Subject: [PATCH 292/356] Step 18.45: View for Register
 
 ---
  imports/ui/components/register/register.html | 72 ++++++++++++++++++++++++++++
@@ -10403,10 +10403,10 @@ index 0000000..37b42c6
 2.5.0
 
 
-From f5ecbeb48e0a5eb1fb35c107781c7e1260c31552 Mon Sep 17 00:00:00 2001
+From 739bfc035517dc1223975ec013a542fdff129d18 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:46:15 +0200
-Subject: [PATCH 293/303] Step 18.46: Create Register
+Subject: [PATCH 293/356] Step 18.46: Create Register
 
 ---
  imports/ui/components/register/register.js | 58 ++++++++++++++++++++++++++++++
@@ -10481,10 +10481,10 @@ index 0000000..91b108c
 2.5.0
 
 
-From 58d35488f4711f5fa9dbd210e0329805a9f4eb6e Mon Sep 17 00:00:00 2001
+From 0b086ef72789f6f18e415aacaacca99a868feea7 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:46:55 +0200
-Subject: [PATCH 294/303] Step 18.47: Add Register to Auth
+Subject: [PATCH 294/356] Step 18.47: Add Register to Auth
 
 ---
  imports/ui/components/auth/auth.js | 4 +++-
@@ -10516,10 +10516,10 @@ index 9c5de5a..e4b40a5 100644
 2.5.0
 
 
-From 7ad258549283884be3666f1c8e83429b941cbd4f Mon Sep 17 00:00:00 2001
+From be9fe52a3109742907e5c64c658a1b4dbcf3aaf2 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:47:29 +0200
-Subject: [PATCH 295/303] Step 18.48: View for Password
+Subject: [PATCH 295/356] Step 18.48: View for Password
 
 ---
  imports/ui/components/password/password.html | 40 ++++++++++++++++++++++++++++
@@ -10576,10 +10576,10 @@ index 0000000..94df2b0
 2.5.0
 
 
-From 796d9fc45e7ceb8ea1edc8996bc74d3838519843 Mon Sep 17 00:00:00 2001
+From 6bb21c4b1a90014eafb371f5cf5e1d7db0bc0e2a Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:48:03 +0200
-Subject: [PATCH 296/303] Step 18.49: Create Password
+Subject: [PATCH 296/356] Step 18.49: Create Password
 
 ---
  imports/ui/components/password/password.js | 56 ++++++++++++++++++++++++++++++
@@ -10652,10 +10652,10 @@ index 0000000..946f013
 2.5.0
 
 
-From 3157afbb8c02b639bb0329339fe839bb645eee75 Mon Sep 17 00:00:00 2001
+From 5425df9ca02e1898e50ec85d4e8e3db47aa1900a Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:48:33 +0200
-Subject: [PATCH 297/303] Step 18.50: Add Password to Auth
+Subject: [PATCH 297/356] Step 18.50: Add Password to Auth
 
 ---
  imports/ui/components/auth/auth.js | 4 +++-
@@ -10687,10 +10687,10 @@ index e4b40a5..a780572 100644
 2.5.0
 
 
-From 610c15c668a37e3ce9ecf8dc811a305d097ea178 Mon Sep 17 00:00:00 2001
+From fde5deabeafd03b63c96e523f6f1799f0f10b247 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:50:12 +0200
-Subject: [PATCH 298/303] Step 18.51: Add Auth to Socially
+Subject: [PATCH 298/356] Step 18.51: Add Auth to Socially
 
 ---
  imports/ui/components/socially/socially.js | 2 ++
@@ -10720,10 +10720,10 @@ index 4cd8e0c..565f42f 100644
 2.5.0
 
 
-From 4b2afdc8d1c141b1a474df91ea8d2d3527b123d5 Mon Sep 17 00:00:00 2001
+From 3696434b0207edde572c6f8068edf6d0069aabc7 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:50:46 +0200
-Subject: [PATCH 299/303] Step 18.52: Implement Auth
+Subject: [PATCH 299/356] Step 18.52: Implement Auth
 
 ---
  imports/ui/components/navigation/navigation.html | 3 ++-
@@ -10746,10 +10746,10 @@ index 0b1d8a6..2d81bc4 100644
 2.5.0
 
 
-From 48fe64433f66ca2d53d2229b3febcf217f257076 Mon Sep 17 00:00:00 2001
+From 39dcadb1212f4cc32b695eaaf668a17dcb334571 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:51:45 +0200
-Subject: [PATCH 300/303] Step 18.53: Remove .less of Navigation
+Subject: [PATCH 300/356] Step 18.53: Remove .less of Navigation
 
 ---
  imports/ui/components/navigation/navigation.less | 5 -----
@@ -10771,10 +10771,10 @@ index 87b8777..0000000
 2.5.0
 
 
-From 495ba0ed23d6d369759685dd5201d7edebaa31e1 Mon Sep 17 00:00:00 2001
+From d2a12e535d998a902ea351ccd9c48be83ac88fa7 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 03:52:12 +0200
-Subject: [PATCH 301/303] Step 18.54: Remove import statement
+Subject: [PATCH 301/356] Step 18.54: Remove import statement
 
 ---
  imports/ui/components/socially/socially.less | 2 --
@@ -10796,10 +10796,2043 @@ index 3eabc12..742f92d 100644
 2.5.0
 
 
-From 291d783c573a994d135b57d7ea1060d62004421d Mon Sep 17 00:00:00 2001
+From a78619170ee768589c8de459e62dc25a40d4a1be Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 12:38:56 +0200
+Subject: [PATCH 302/356] Step 20.1: Add `jalik:ufs`
+
+---
+ .meteor/packages | 1 +
+ .meteor/versions | 2 ++
+ 2 files changed, 3 insertions(+)
+
+diff --git a/.meteor/packages b/.meteor/packages
+index c6567f3..182ec84 100644
+--- a/.meteor/packages
++++ b/.meteor/packages
+@@ -29,3 +29,4 @@ check
+ email
+ less
+ planettraining:material-design-icons
++jalik:ufs
+diff --git a/.meteor/versions b/.meteor/versions
+index fb2822c..234e26b 100644
+--- a/.meteor/versions
++++ b/.meteor/versions
+@@ -42,12 +42,14 @@ html-tools@1.0.9
+ htmljs@1.0.9
+ http@1.1.5
+ id-map@1.0.7
++jalik:ufs@0.5.3
+ jquery@1.11.8
+ launch-screen@1.0.11
+ less@2.5.6
+ livedata@1.0.18
+ localstorage@1.0.7
+ logging@1.0.12
++matb33:collection-hooks@0.7.15
+ meteor@1.1.14
+ meteor-base@1.0.4
+ minifier-css@1.1.11
+-- 
+2.5.0
+
+
+From ae6fd83d3aac696a4c63ba4d21bd89701a79311d Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 12:40:52 +0200
+Subject: [PATCH 303/356] Step 20.2: Add `jalik:ufs-gridfs`
+
+---
+ .meteor/packages | 1 +
+ .meteor/versions | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/.meteor/packages b/.meteor/packages
+index 182ec84..57c1f6b 100644
+--- a/.meteor/packages
++++ b/.meteor/packages
+@@ -30,3 +30,4 @@ email
+ less
+ planettraining:material-design-icons
+ jalik:ufs
++jalik:ufs-gridfs
+diff --git a/.meteor/versions b/.meteor/versions
+index 234e26b..abe42a2 100644
+--- a/.meteor/versions
++++ b/.meteor/versions
+@@ -43,6 +43,7 @@ htmljs@1.0.9
+ http@1.1.5
+ id-map@1.0.7
+ jalik:ufs@0.5.3
++jalik:ufs-gridfs@0.1.1
+ jquery@1.11.8
+ launch-screen@1.0.11
+ less@2.5.6
+-- 
+2.5.0
+
+
+From 44cc4f7e95be057c8679b05a84b17fc72c2147f3 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 12:48:58 +0200
+Subject: [PATCH 304/356] Step 20.3: Create Images and Thumbs collections
+
+---
+ imports/api/images/collection.js | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+ create mode 100644 imports/api/images/collection.js
+
+diff --git a/imports/api/images/collection.js b/imports/api/images/collection.js
+new file mode 100644
+index 0000000..a522111
+--- /dev/null
++++ b/imports/api/images/collection.js
+@@ -0,0 +1,21 @@
++import { Meteor } from 'meteor/meteor';
++import { Mongo } from 'meteor/mongo';
++
++export const Images = new Mongo.Collection('images');
++export const Thumbs = new Mongo.Collection('thumbs');
++
++function loggedIn(userId) {
++  return !!userId;
++}
++
++Thumbs.allow({
++  insert: loggedIn,
++  update: loggedIn,
++  remove: loggedIn
++});
++
++Images.allow({
++  insert: loggedIn,
++  update: loggedIn,
++  remove: loggedIn
++});
+-- 
+2.5.0
+
+
+From 40918489202b9717068fb4f76b3da7035fff334a Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 12:50:11 +0200
+Subject: [PATCH 305/356] Step 20.4: Create ThumbsStore and ImagesStore
+
+---
+ imports/api/images/store.js | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+ create mode 100644 imports/api/images/store.js
+
+diff --git a/imports/api/images/store.js b/imports/api/images/store.js
+new file mode 100644
+index 0000000..58462c1
+--- /dev/null
++++ b/imports/api/images/store.js
+@@ -0,0 +1,18 @@
++import { UploadFS } from 'meteor/jalik:ufs';
++import { Images, Thumbs } from './collection';
++
++export const ThumbsStore = new UploadFS.store.GridFS({
++  collection: Thumbs,
++  name: 'thumbs'
++});
++
++export const ImagesStore = new UploadFS.store.GridFS({
++  collection: Images,
++  name: 'images',
++  filter: new UploadFS.Filter({
++    contentTypes: ['image/*']
++  }),
++  copyTo: [
++    ThumbsStore
++  ]
++});
+-- 
+2.5.0
+
+
+From dc18b7280aaada9e1c8ed9bd1da0b49b4125f08c Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 12:50:57 +0200
+Subject: [PATCH 306/356] Step 20.5: Create main export file of Images and
+ Thumbs
+
+---
+ imports/api/images/index.js | 2 ++
+ 1 file changed, 2 insertions(+)
+ create mode 100644 imports/api/images/index.js
+
+diff --git a/imports/api/images/index.js b/imports/api/images/index.js
+new file mode 100644
+index 0000000..9c18361
+--- /dev/null
++++ b/imports/api/images/index.js
+@@ -0,0 +1,2 @@
++export * from './collection';
++export * from './store';
+-- 
+2.5.0
+
+
+From c57e4c525e5b2244892217c255fb1faae1390313 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 12:52:30 +0200
+Subject: [PATCH 307/356] Step 20.6: Resize images
+
+---
+ imports/api/images/store.js | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/imports/api/images/store.js b/imports/api/images/store.js
+index 58462c1..a0fa6d6 100644
+--- a/imports/api/images/store.js
++++ b/imports/api/images/store.js
+@@ -3,7 +3,19 @@ import { Images, Thumbs } from './collection';
+ 
+ export const ThumbsStore = new UploadFS.store.GridFS({
+   collection: Thumbs,
+-  name: 'thumbs'
++  name: 'thumbs',
++  transformWrite(from, to, fileId, file) {
++    // Resize to 32x32
++    const gm = require('gm');
++
++    gm(from, file.name)
++      .resize(32, 32)
++      .gravity('Center')
++      .extent(32, 32)
++      .quality(75)
++      .stream()
++      .pipe(to);
++  }
+ });
+ 
+ export const ImagesStore = new UploadFS.store.GridFS({
+-- 
+2.5.0
+
+
+From 4b2df2acc0eb2d4fb352e11b711c1a0afb2b8dc7 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 12:54:06 +0200
+Subject: [PATCH 308/356] Step 20.7: Install `gm`
+
+---
+ package.json | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/package.json b/package.json
+index 4e726a8..19b4b6e 100644
+--- a/package.json
++++ b/package.json
+@@ -16,6 +16,7 @@
+     "angular-simple-logger": "^0.1.7",
+     "angular-ui-router": "^1.0.0-alpha.4",
+     "angular-utils-pagination": "^0.11.1",
++    "gm": "^1.22.0",
+     "meteor-node-stubs": "~0.2.0",
+     "underscore": "^1.8.3"
+   },
+-- 
+2.5.0
+
+
+From c1232b29f6fc40ce1ba3decb81ff1295a605447e Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 12:58:21 +0200
+Subject: [PATCH 309/356] Step 20.8: Create view for PartyUpload
+
+---
+ imports/ui/components/partyUpload/partyUpload.html | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+ create mode 100644 imports/ui/components/partyUpload/partyUpload.html
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.html b/imports/ui/components/partyUpload/partyUpload.html
+new file mode 100644
+index 0000000..d53d6c7
+--- /dev/null
++++ b/imports/ui/components/partyUpload/partyUpload.html
+@@ -0,0 +1,9 @@
++<div layout="column">
++  <div>
++      <div>Click here to select image</div>
++      <div>
++        <strong>OR</strong>
++      </div>
++      <div>You can also drop image to here</div>
++  </div>
++</div>
+-- 
+2.5.0
+
+
+From 39bcf4d0a47e17d83d78c946e375f70d5c5209ba Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 12:59:42 +0200
+Subject: [PATCH 310/356] Step 20.9: Create PartyUpload component
+
+---
+ imports/ui/components/partyUpload/partyUpload.js | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+ create mode 100644 imports/ui/components/partyUpload/partyUpload.js
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.js b/imports/ui/components/partyUpload/partyUpload.js
+new file mode 100644
+index 0000000..9a48483
+--- /dev/null
++++ b/imports/ui/components/partyUpload/partyUpload.js
+@@ -0,0 +1,19 @@
++import angular from 'angular';
++import angularMeteor from 'angular-meteor';
++
++import { Meteor } from 'meteor/meteor';
++
++import './partyUpload.html';
++
++class PartyUpload {}
++
++const name = 'partyUpload';
++
++// create a module
++export default angular.module(name, [
++  angularMeteor
++]).component(name, {
++  templateUrl: `imports/ui/components/${name}/${name}.html`,
++  controllerAs: name,
++  controller: PartyUpload
++});
+-- 
+2.5.0
+
+
+From 779d86cb75ad633e4c75e77fe6eb7a108120dfe7 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:01:32 +0200
+Subject: [PATCH 311/356] Step 20.10: Add to PartyAdd
+
+---
+ imports/ui/components/partyAdd/partyAdd.js | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/imports/ui/components/partyAdd/partyAdd.js b/imports/ui/components/partyAdd/partyAdd.js
+index 0b1d240..2cda43f 100644
+--- a/imports/ui/components/partyAdd/partyAdd.js
++++ b/imports/ui/components/partyAdd/partyAdd.js
+@@ -5,6 +5,7 @@ import { Meteor } from 'meteor/meteor';
+ 
+ import './partyAdd.html';
+ import { Parties } from '../../../api/parties';
++import { name as PartyUpload } from '../partyUpload/partyUpload';
+ 
+ class PartyAdd {
+   constructor() {
+@@ -18,7 +19,7 @@ class PartyAdd {
+     if(this.done) {
+       this.done();
+     }
+-    
++
+     this.reset();
+   }
+ 
+@@ -31,7 +32,8 @@ const name = 'partyAdd';
+ 
+ // create a module
+ export default angular.module(name, [
+-  angularMeteor
++  angularMeteor,
++  PartyUpload
+ ]).component(name, {
+   templateUrl: `imports/ui/components/${name}/${name}.html`,
+   bindings: {
+-- 
+2.5.0
+
+
+From 7c1725c71ab4b41a53dd2de0760375f4101fa23d Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:03:51 +0200
+Subject: [PATCH 312/356] Step 20.11: Implement to the view
+
+---
+ imports/ui/components/partyAdd/partyAdd.html | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/imports/ui/components/partyAdd/partyAdd.html b/imports/ui/components/partyAdd/partyAdd.html
+index 6e504f0..8946e6d 100644
+--- a/imports/ui/components/partyAdd/partyAdd.html
++++ b/imports/ui/components/partyAdd/partyAdd.html
+@@ -19,4 +19,5 @@
+   <div flex>
+     <md-button ng-click="partyAdd.submit()" class="md-raised">Add Party!</md-button>
+   </div>
++  <party-upload files="partyAdd.party.images"></party-upload>
+ </div>
+-- 
+2.5.0
+
+
+From 990bb900e6c9d7f8c41781d546eaf685f0ef2bfa Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:05:32 +0200
+Subject: [PATCH 313/356] Step 20.12: install `ng-file-upload`
+
+---
+ package.json | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/package.json b/package.json
+index 19b4b6e..c19d6de 100644
+--- a/package.json
++++ b/package.json
+@@ -18,6 +18,7 @@
+     "angular-utils-pagination": "^0.11.1",
+     "gm": "^1.22.0",
+     "meteor-node-stubs": "~0.2.0",
++    "ng-file-upload": "^12.0.4",
+     "underscore": "^1.8.3"
+   },
+   "devDependencies": {
+-- 
+2.5.0
+
+
+From 574e6437f6fc2fc45ab4db4015b244f9f46eb59e Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:08:06 +0200
+Subject: [PATCH 314/356] Step 20.13: Add as a dependency
+
+---
+ imports/ui/components/partyUpload/partyUpload.js | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.js b/imports/ui/components/partyUpload/partyUpload.js
+index 9a48483..ecbf8d3 100644
+--- a/imports/ui/components/partyUpload/partyUpload.js
++++ b/imports/ui/components/partyUpload/partyUpload.js
+@@ -1,5 +1,6 @@
+ import angular from 'angular';
+ import angularMeteor from 'angular-meteor';
++import ngFileUpload from 'ng-file-upload';
+ 
+ import { Meteor } from 'meteor/meteor';
+ 
+@@ -11,7 +12,8 @@ const name = 'partyUpload';
+ 
+ // create a module
+ export default angular.module(name, [
+-  angularMeteor
++  angularMeteor,
++  ngFileUpload
+ ]).component(name, {
+   templateUrl: `imports/ui/components/${name}/${name}.html`,
+   controllerAs: name,
+-- 
+2.5.0
+
+
+From 5057fab32cd33913c407add8da09b93ca9bdc186 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:09:13 +0200
+Subject: [PATCH 315/356] Step 20.14: Add ngf-drop to the view
+
+---
+ imports/ui/components/partyUpload/partyUpload.html | 21 +++++++++++++++------
+ 1 file changed, 15 insertions(+), 6 deletions(-)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.html b/imports/ui/components/partyUpload/partyUpload.html
+index d53d6c7..70e5af3 100644
+--- a/imports/ui/components/partyUpload/partyUpload.html
++++ b/imports/ui/components/partyUpload/partyUpload.html
+@@ -1,9 +1,18 @@
+ <div layout="column">
+-  <div>
+-      <div>Click here to select image</div>
+-      <div>
+-        <strong>OR</strong>
+-      </div>
+-      <div>You can also drop image to here</div>
++  <div ngf-drop
++    ngf-select
++    ngf-change="partyUpload.addImages($files)"
++    ngf-drag-over-class="{accept:'dragover', reject:'dragover-err', delay:100}"
++    class="drop-box"
++    ngf-multiple="false"
++    ngf-allow-dir="false"
++    ngf-accept="'image/*'"
++    ngf-drop-available="true"
++    ng-hide="partyUpload.cropImgSrc">
++    <div>Click here to select image</div>
++    <div>
++      <strong>OR</strong>
++    </div>
++    <div>You can also drop image to here</div>
+   </div>
+ </div>
+-- 
+2.5.0
+
+
+From 3f993ea7208119e5dfec605df24f24fd1b96894d Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:12:52 +0200
+Subject: [PATCH 316/356] Step 20.15: Handle file selection
+
+---
+ imports/ui/components/partyUpload/partyUpload.js | 25 +++++++++++++++++++++++-
+ 1 file changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.js b/imports/ui/components/partyUpload/partyUpload.js
+index ecbf8d3..14d5ae6 100644
+--- a/imports/ui/components/partyUpload/partyUpload.js
++++ b/imports/ui/components/partyUpload/partyUpload.js
+@@ -6,7 +6,30 @@ import { Meteor } from 'meteor/meteor';
+ 
+ import './partyUpload.html';
+ 
+-class PartyUpload {}
++class PartyUpload {
++  constructor($scope, $reactive) {
++    'ngInject';
++
++    $reactive(this).attach($scope);
++  }
++
++  addImages(files) {
++    if (files.length) {
++      this.currentFile = files[0];
++
++      const reader = new FileReader;
++
++      reader.onload = this.$bindToContext((e) => {
++        this.cropImgSrc = e.target.result;
++        this.myCroppedImage = '';
++      });
++
++      reader.readAsDataURL(files[0]);
++    } else {
++      this.cropImgSrc = undefined;
++    }
++  }
++}
+ 
+ const name = 'partyUpload';
+ 
+-- 
+2.5.0
+
+
+From 110d0502b28aae83eeef7cfd5c2f7e8e72f32b7e Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:15:21 +0200
+Subject: [PATCH 317/356] Step 20.16: Add style
+
+---
+ imports/ui/components/partyUpload/partyUpload.less | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+ create mode 100644 imports/ui/components/partyUpload/partyUpload.less
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.less b/imports/ui/components/partyUpload/partyUpload.less
+new file mode 100644
+index 0000000..987a853
+--- /dev/null
++++ b/imports/ui/components/partyUpload/partyUpload.less
+@@ -0,0 +1,16 @@
++party-upload {
++  .drop-box {
++    background: #F8F8F8;
++    border: 5px dashed #DDD;
++    text-align: center;
++    padding: 25px;
++    margin-left: 10px;
++    margin-bottom: 20px;
++  }
++  .drop-box.dragover {
++    border: 5px dashed blue;
++  }
++  .drop-box.dragover-err {
++    border: 5px dashed red;
++  }
++}
+-- 
+2.5.0
+
+
+From 25f2d8a282b9574ec59649371db5966a1c404957 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:15:42 +0200
+Subject: [PATCH 318/356] Step 20.17: Import in PartyAdd
+
+---
+ imports/ui/components/partyAdd/partyAdd.less | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 imports/ui/components/partyAdd/partyAdd.less
+
+diff --git a/imports/ui/components/partyAdd/partyAdd.less b/imports/ui/components/partyAdd/partyAdd.less
+new file mode 100644
+index 0000000..18bfd78
+--- /dev/null
++++ b/imports/ui/components/partyAdd/partyAdd.less
+@@ -0,0 +1 @@
++@import "../partyUpload/partyUpload.less";
+-- 
+2.5.0
+
+
+From 0ad331cb2a8d78208b2ac2e94fe185d54cf342d1 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:16:18 +0200
+Subject: [PATCH 319/356] Step 20.18: Import in PartyAddButton
+
+---
+ imports/ui/components/partyAddButton/partyAddButton.less | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/imports/ui/components/partyAddButton/partyAddButton.less b/imports/ui/components/partyAddButton/partyAddButton.less
+index 73828f6..1b95052 100644
+--- a/imports/ui/components/partyAddButton/partyAddButton.less
++++ b/imports/ui/components/partyAddButton/partyAddButton.less
+@@ -5,3 +5,4 @@ party-add-button {
+     bottom: 15px;
+   }
+ }
++@import "../partyAdd/partyAdd.less";
+-- 
+2.5.0
+
+
+From c84a16ae35860a5db843e641fc282891d2b21f28 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:17:27 +0200
+Subject: [PATCH 320/356] Step 20.19: Install `ng-img-crop`
+
+---
+ package.json | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/package.json b/package.json
+index c19d6de..52236c7 100644
+--- a/package.json
++++ b/package.json
+@@ -19,6 +19,7 @@
+     "gm": "^1.22.0",
+     "meteor-node-stubs": "~0.2.0",
+     "ng-file-upload": "^12.0.4",
++    "ng-img-crop": "^0.2.0",
+     "underscore": "^1.8.3"
+   },
+   "devDependencies": {
+-- 
+2.5.0
+
+
+From 4e1101d34bec054dcfd722334de100ade0cbe372 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:27:50 +0200
+Subject: [PATCH 321/356] Step 20.20: Add ngImgCrop
+
+---
+ imports/ui/components/partyUpload/partyUpload.js | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.js b/imports/ui/components/partyUpload/partyUpload.js
+index 14d5ae6..74f3a63 100644
+--- a/imports/ui/components/partyUpload/partyUpload.js
++++ b/imports/ui/components/partyUpload/partyUpload.js
+@@ -1,6 +1,9 @@
+ import angular from 'angular';
+ import angularMeteor from 'angular-meteor';
+ import ngFileUpload from 'ng-file-upload';
++import 'ng-img-crop/compile/minified/ng-img-crop';
++import 'ng-img-crop/compile/minified/ng-img-crop.css';
++
+ 
+ import { Meteor } from 'meteor/meteor';
+ 
+@@ -36,7 +39,8 @@ const name = 'partyUpload';
+ // create a module
+ export default angular.module(name, [
+   angularMeteor,
+-  ngFileUpload
++  ngFileUpload,
++  'ngImgCrop'
+ ]).component(name, {
+   templateUrl: `imports/ui/components/${name}/${name}.html`,
+   controllerAs: name,
+-- 
+2.5.0
+
+
+From 4b225592b5bf43dd529046ab0a3245b3caa4bc61 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:31:51 +0200
+Subject: [PATCH 322/356] Step 20.21: Use ngImgCrop
+
+---
+ imports/ui/components/partyUpload/partyUpload.html | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.html b/imports/ui/components/partyUpload/partyUpload.html
+index 70e5af3..2dd38e9 100644
+--- a/imports/ui/components/partyUpload/partyUpload.html
++++ b/imports/ui/components/partyUpload/partyUpload.html
+@@ -15,4 +15,18 @@
+     </div>
+     <div>You can also drop image to here</div>
+   </div>
++  <div ng-show="partyUpload.cropImgSrc" layout="column" class="ng-crop">
++    <div>
++      <h3>Edit &amp; crop</h3>
++      <md-button ng-click="partyUpload.save()" class="md-primary">
++        Save Image
++      </md-button>
++      <md-button ng-click="partyUpload.reset()">
++        Cancel
++      </md-button>
++    </div>
++    <div class="ng-crop-container">
++      <img-crop image="partyUpload.cropImgSrc" result-image="partyUpload.myCroppedImage" area-type="square"></img-crop>
++    </div>
++  </div>
+ </div>
+-- 
+2.5.0
+
+
+From b76cd1e1be6af90dfc63a406fbd27183ea6aac46 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 13:32:11 +0200
+Subject: [PATCH 323/356] Step 20.22: Add styles
+
+---
+ imports/ui/components/partyUpload/partyUpload.less | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.less b/imports/ui/components/partyUpload/partyUpload.less
+index 987a853..645cee2 100644
+--- a/imports/ui/components/partyUpload/partyUpload.less
++++ b/imports/ui/components/partyUpload/partyUpload.less
+@@ -13,4 +13,13 @@ party-upload {
+   .drop-box.dragover-err {
+     border: 5px dashed red;
+   }
++  .ng-crop {
++    h3 {
++      margin-top: 0;
++    }
++  }
++  .ng-crop-container {
++    width: 400px;
++    height: 225px;
++  }
+ }
+-- 
+2.5.0
+
+
+From 59f088e68145ddacf38bcc3c049efa4195a3b199 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:02:41 +0200
+Subject: [PATCH 324/356] Step 20.23: Add dataURLToBlob helper
+
+---
+ imports/api/images/helpers.js | 31 +++++++++++++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+ create mode 100644 imports/api/images/helpers.js
+
+diff --git a/imports/api/images/helpers.js b/imports/api/images/helpers.js
+new file mode 100644
+index 0000000..23f1350
+--- /dev/null
++++ b/imports/api/images/helpers.js
+@@ -0,0 +1,31 @@
++/**
++ * Converts DataURL to Blob object
++ *
++ * https://github.com/ebidel/filer.js/blob/master/src/filer.js#L137
++ *
++ * @param  {String} dataURL
++ * @return {Blob}
++ */
++export function dataURLToBlob(dataURL) {
++    const BASE64_MARKER = ';base64,';
++
++    if (dataURL.indexOf(BASE64_MARKER) === -1) {
++      const parts = dataURL.split(',');
++      const contentType = parts[0].split(':')[1];
++      const raw = decodeURIComponent(parts[1]);
++
++      return new Blob([raw], {type: contentType});
++    }
++
++    const parts = dataURL.split(BASE64_MARKER);
++    const contentType = parts[0].split(':')[1];
++    const raw = window.atob(parts[1]);
++    const rawLength = raw.length;
++    const uInt8Array = new Uint8Array(rawLength);
++
++    for (let i = 0; i < rawLength; ++i) {
++      uInt8Array[i] = raw.charCodeAt(i);
++    }
++
++    return new Blob([uInt8Array], {type: contentType});
++}
+-- 
+2.5.0
+
+
+From b771c39283144d83be8b4a18e8c7369a5d83567a Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:05:04 +0200
+Subject: [PATCH 325/356] Step 20.24: Add blobToArrayBuffer helper
+
+---
+ imports/api/images/helpers.js | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/imports/api/images/helpers.js b/imports/api/images/helpers.js
+index 23f1350..448f932 100644
+--- a/imports/api/images/helpers.js
++++ b/imports/api/images/helpers.js
+@@ -29,3 +29,26 @@ export function dataURLToBlob(dataURL) {
+ 
+     return new Blob([uInt8Array], {type: contentType});
+ }
++
++/**
++ * Converts Blob object to ArrayBuffer
++ *
++ * @param  {Blob}       blob          Source file
++ * @param  {Function}   callback      Success callback with converted object as a first argument
++ * @param  {Function}   errorCallback Error callback with error as a first argument
++ */
++export function blobToArrayBuffer(blob, callback, errorCallback) {
++  const reader = new FileReader();
++
++  reader.onload = (e) => {
++    callback(e.target.result);
++  };
++
++  reader.onerror = (e) => {
++    if (errorCallback) {
++      errorCallback(e);
++    }
++  };
++
++  reader.readAsArrayBuffer(blob);
++}
+-- 
+2.5.0
+
+
+From bf4eb622deb7738c804c0ab0f44cc58fc65c605e Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:08:29 +0200
+Subject: [PATCH 326/356] Step 20.25: Create `upload` method
+
+---
+ imports/api/images/methods.js | 33 +++++++++++++++++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+ create mode 100644 imports/api/images/methods.js
+
+diff --git a/imports/api/images/methods.js b/imports/api/images/methods.js
+new file mode 100644
+index 0000000..e634901
+--- /dev/null
++++ b/imports/api/images/methods.js
+@@ -0,0 +1,33 @@
++import { UploadFS } from 'meteor/jalik:ufs';
++import { ImagesStore } from './store';
++import { dataURLToBlob, blobToArrayBuffer } from './helpers';
++
++/**
++ * Uploads a new file
++ *
++ * @param  {String}   dataUrl [description]
++ * @param  {String}   name    [description]
++ * @param  {Function} resolve [description]
++ * @param  {Function} reject  [description]
++ */
++export function upload(dataUrl, name, resolve, reject) {
++  // convert to Blob
++  const blob = dataURLToBlob(dataUrl);
++  blob.name = name;
++
++  // pick from an object only: name, type and size
++  const file = _.pick(blob, 'name', 'type', 'size');
++
++  // convert to ArrayBuffer
++  blobToArrayBuffer(blob, (data) => {
++    const upload = new UploadFS.Uploader({
++      data,
++      file,
++      store: ImagesStore,
++      onError: reject,
++      onComplete: resolve
++    });
++
++    upload.start();
++  }, reject);
++}
+-- 
+2.5.0
+
+
+From 8a8582a32de5780bd3ce411af0bdf32cb7a7a8ac Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:08:56 +0200
+Subject: [PATCH 327/356] Step 20.26: Export methods
+
+---
+ imports/api/images/index.js | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/imports/api/images/index.js b/imports/api/images/index.js
+index 9c18361..74293fe 100644
+--- a/imports/api/images/index.js
++++ b/imports/api/images/index.js
+@@ -1,2 +1,3 @@
+ export * from './collection';
+ export * from './store';
++export * from './methods';
+-- 
+2.5.0
+
+
+From 2b358e99d41e10dbaf5308bb9372119f7b579905 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:15:15 +0200
+Subject: [PATCH 328/356] Step 20.27: Implement `save` and `reset` methods
+
+---
+ imports/ui/components/partyUpload/partyUpload.js | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.js b/imports/ui/components/partyUpload/partyUpload.js
+index 74f3a63..2b8885a 100644
+--- a/imports/ui/components/partyUpload/partyUpload.js
++++ b/imports/ui/components/partyUpload/partyUpload.js
+@@ -8,12 +8,15 @@ import 'ng-img-crop/compile/minified/ng-img-crop.css';
+ import { Meteor } from 'meteor/meteor';
+ 
+ import './partyUpload.html';
++import { upload } from '../../../api/images';
+ 
+ class PartyUpload {
+   constructor($scope, $reactive) {
+     'ngInject';
+ 
+     $reactive(this).attach($scope);
++
++    this.uploaded = [];
+   }
+ 
+   addImages(files) {
+@@ -32,6 +35,20 @@ class PartyUpload {
+       this.cropImgSrc = undefined;
+     }
+   }
++
++  save() {
++    upload(this.myCroppedImage, this.currentFile.name, this.$bindToContext((file) => {
++      this.uploaded.push(file);
++      this.reset();
++    }), (e) => {
++      console.log('Oops, something went wrong', e);
++    });
++  }
++
++  reset() {
++    this.cropImgSrc = undefined;
++    this.myCroppedImage = '';
++  }
+ }
+ 
+ const name = 'partyUpload';
+-- 
+2.5.0
+
+
+From 99d01de61a4c22ea7461fb13bdded5eb5780d284 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:16:03 +0200
+Subject: [PATCH 329/356] Step 20.28: Import Images on server side
+
+---
+ server/main.js | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/server/main.js b/server/main.js
+index 1acdc6c..2b47936 100644
+--- a/server/main.js
++++ b/server/main.js
+@@ -1,3 +1,4 @@
+ import '../imports/startup/fixtures';
+ import '../imports/api/parties';
+ import '../imports/api/users';
++import '../imports/api/images';
+-- 
+2.5.0
+
+
+From e55271cc451b43e0f5beb93156d82cd12267fee7 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:21:33 +0200
+Subject: [PATCH 330/356] Step 20.29: Display uploaded images
+
+---
+ imports/ui/components/partyUpload/partyUpload.html | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.html b/imports/ui/components/partyUpload/partyUpload.html
+index 2dd38e9..124bfdb 100644
+--- a/imports/ui/components/partyUpload/partyUpload.html
++++ b/imports/ui/components/partyUpload/partyUpload.html
+@@ -29,4 +29,9 @@
+       <img-crop image="partyUpload.cropImgSrc" result-image="partyUpload.myCroppedImage" area-type="square"></img-crop>
+     </div>
+   </div>
++  <div layout="row" class="images-container-title">
++    <div class="party-image-container" ng-class="{'main-image': $index === 0}" ng-repeat="thumb in partyUpload.thumbs">
++      <img ng-src="{{ thumb.url }}"/>
++    </div>
++  </div>
+ </div>
+-- 
+2.5.0
+
+
+From 4e9c2f5502088f2c740547aa2cdd7d7b26333758 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:22:36 +0200
+Subject: [PATCH 331/356] Step 20.30: Add styles
+
+---
+ imports/ui/components/partyUpload/partyUpload.less | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.less b/imports/ui/components/partyUpload/partyUpload.less
+index 645cee2..f781c1c 100644
+--- a/imports/ui/components/partyUpload/partyUpload.less
++++ b/imports/ui/components/partyUpload/partyUpload.less
+@@ -22,4 +22,20 @@ party-upload {
+     width: 400px;
+     height: 225px;
+   }
++  .images-container-title {
++    padding-bottom: 30px;
++  }
++  .party-image-container {
++    position: relative;
++    margin-right: 10px;
++    max-height: 200px;
++    max-width: 200px;
++    img {
++      max-height: 100%;
++      max-width: 100%;
++    }
++  }
++  .main-image {
++    border: 2px solid #ddd;
++  }
+ }
+-- 
+2.5.0
+
+
+From 90715bdc36e5bc0df7d89b664f9074ff57355936 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:24:09 +0200
+Subject: [PATCH 332/356] Step 20.31: Add `thumbs` and `images` publications
+
+---
+ imports/api/images/publish.js | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+ create mode 100644 imports/api/images/publish.js
+
+diff --git a/imports/api/images/publish.js b/imports/api/images/publish.js
+new file mode 100644
+index 0000000..5949c72
+--- /dev/null
++++ b/imports/api/images/publish.js
+@@ -0,0 +1,17 @@
++import { Meteor } from 'meteor/meteor';
++import { Thumbs, Images } from './collection';
++
++if (Meteor.isServer) {
++  Meteor.publish('thumbs', function(ids) {
++    return Thumbs.find({
++      originalStore: 'images',
++      originalId: {
++        $in: ids
++      }
++    });
++  });
++
++  Meteor.publish('images', function() {
++    return Images.find({});
++  });
++}
+-- 
+2.5.0
+
+
+From b4f40f5fe97e8895d9ecd17f8504608e37f32d26 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:24:36 +0200
+Subject: [PATCH 333/356] Step 20.32: Import publications
+
+---
+ imports/api/images/index.js | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/imports/api/images/index.js b/imports/api/images/index.js
+index 74293fe..57692b3 100644
+--- a/imports/api/images/index.js
++++ b/imports/api/images/index.js
+@@ -1,3 +1,4 @@
++import './publish';
+ export * from './collection';
+ export * from './store';
+ export * from './methods';
+-- 
+2.5.0
+
+
+From 2062f9b8b5f777c0560f419f0a06796d2194064a Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:29:08 +0200
+Subject: [PATCH 334/356] Step 20.33: Implement thumbnails
+
+---
+ imports/ui/components/partyUpload/partyUpload.js | 23 ++++++++++++++++++++++-
+ 1 file changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.js b/imports/ui/components/partyUpload/partyUpload.js
+index 2b8885a..ab3b53c 100644
+--- a/imports/ui/components/partyUpload/partyUpload.js
++++ b/imports/ui/components/partyUpload/partyUpload.js
+@@ -8,7 +8,7 @@ import 'ng-img-crop/compile/minified/ng-img-crop.css';
+ import { Meteor } from 'meteor/meteor';
+ 
+ import './partyUpload.html';
+-import { upload } from '../../../api/images';
++import { Thumbs, upload } from '../../../api/images';
+ 
+ class PartyUpload {
+   constructor($scope, $reactive) {
+@@ -17,6 +17,21 @@ class PartyUpload {
+     $reactive(this).attach($scope);
+ 
+     this.uploaded = [];
++
++    this.subscribe('thumbs', () => [
++      this.getReactively('files', true) || []
++    ]);
++
++    this.helpers({
++      thumbs() {
++        return Thumbs.find({
++          originalStore: 'images',
++          originalId: {
++            $in: this.getReactively('files', true) || []
++          }
++        });
++      }
++    });
+   }
+ 
+   addImages(files) {
+@@ -39,6 +54,12 @@ class PartyUpload {
+   save() {
+     upload(this.myCroppedImage, this.currentFile.name, this.$bindToContext((file) => {
+       this.uploaded.push(file);
++
++      if (!this.files || !this.files.length) {
++        this.files = [];
++      }
++      this.files.push(file._id);
++
+       this.reset();
+     }), (e) => {
+       console.log('Oops, something went wrong', e);
+-- 
+2.5.0
+
+
+From b070776693cde4380d8a63a95f24c97934def214 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:32:41 +0200
+Subject: [PATCH 335/356] Step 20.34: Install `angular-sortable-view`
+
+---
+ package.json | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/package.json b/package.json
+index 52236c7..6f05158 100644
+--- a/package.json
++++ b/package.json
+@@ -14,6 +14,7 @@
+     "angular-messages": "^1.5.3",
+     "angular-meteor": "^1.3.9",
+     "angular-simple-logger": "^0.1.7",
++    "angular-sortable-view": "0.0.15",
+     "angular-ui-router": "^1.0.0-alpha.4",
+     "angular-utils-pagination": "^0.11.1",
+     "gm": "^1.22.0",
+-- 
+2.5.0
+
+
+From 9fb20cd266ac89a6b6a06cf0bc95751a8fcc693a Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:33:09 +0200
+Subject: [PATCH 336/356] Step 20.35: Add as a dependency
+
+---
+ imports/ui/components/partyUpload/partyUpload.js | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.js b/imports/ui/components/partyUpload/partyUpload.js
+index ab3b53c..2f2ff26 100644
+--- a/imports/ui/components/partyUpload/partyUpload.js
++++ b/imports/ui/components/partyUpload/partyUpload.js
+@@ -1,6 +1,7 @@
+ import angular from 'angular';
+ import angularMeteor from 'angular-meteor';
+ import ngFileUpload from 'ng-file-upload';
++import 'angular-sortable-view';
+ import 'ng-img-crop/compile/minified/ng-img-crop';
+ import 'ng-img-crop/compile/minified/ng-img-crop.css';
+ 
+@@ -78,7 +79,8 @@ const name = 'partyUpload';
+ export default angular.module(name, [
+   angularMeteor,
+   ngFileUpload,
+-  'ngImgCrop'
++  'ngImgCrop',
++  'angular-sortable-view'
+ ]).component(name, {
+   templateUrl: `imports/ui/components/${name}/${name}.html`,
+   controllerAs: name,
+-- 
+2.5.0
+
+
+From e9653fd819a844fdcd9189f3f5397e786ea2575c Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 14:33:31 +0200
+Subject: [PATCH 337/356] Step 20.36: Use directives on thumbnails
+
+---
+ imports/ui/components/partyUpload/partyUpload.html | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.html b/imports/ui/components/partyUpload/partyUpload.html
+index 124bfdb..14a3704 100644
+--- a/imports/ui/components/partyUpload/partyUpload.html
++++ b/imports/ui/components/partyUpload/partyUpload.html
+@@ -29,9 +29,9 @@
+       <img-crop image="partyUpload.cropImgSrc" result-image="partyUpload.myCroppedImage" area-type="square"></img-crop>
+     </div>
+   </div>
+-  <div layout="row" class="images-container-title">
+-    <div class="party-image-container" ng-class="{'main-image': $index === 0}" ng-repeat="thumb in partyUpload.thumbs">
+-      <img ng-src="{{ thumb.url }}"/>
++  <div layout="row" class="images-container-title" sv-root sv-part="partyUpload.thumbs">
++    <div sv-element class="party-image-container" ng-class="{'main-image': $index === 0}" ng-repeat="thumb in partyUpload.thumbs">
++      <img draggable="false" ng-src="{{ thumb.url }}"/>
+     </div>
+   </div>
+ </div>
+-- 
+2.5.0
+
+
+From eb02b219531eafc8327f6b862d794ad0a5d8e590 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 15:33:07 +0200
+Subject: [PATCH 338/356] Step 20.37: Define two-way data binding `files`
+
+---
+ imports/ui/components/partyUpload/partyUpload.js | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/imports/ui/components/partyUpload/partyUpload.js b/imports/ui/components/partyUpload/partyUpload.js
+index 2f2ff26..f13d11c 100644
+--- a/imports/ui/components/partyUpload/partyUpload.js
++++ b/imports/ui/components/partyUpload/partyUpload.js
+@@ -83,6 +83,9 @@ export default angular.module(name, [
+   'angular-sortable-view'
+ ]).component(name, {
+   templateUrl: `imports/ui/components/${name}/${name}.html`,
++  bindings: {
++    files: '=?'
++  },
+   controllerAs: name,
+   controller: PartyUpload
+ });
+-- 
+2.5.0
+
+
+From 1548d909b4afb38ba48163d8fd9a556affc71390 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 15:33:24 +0200
+Subject: [PATCH 339/356] Step 20.38: Create view for PartyImage
+
+---
+ imports/ui/components/partyImage/partyImage.html | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 imports/ui/components/partyImage/partyImage.html
+
+diff --git a/imports/ui/components/partyImage/partyImage.html b/imports/ui/components/partyImage/partyImage.html
+new file mode 100644
+index 0000000..719c4a3
+--- /dev/null
++++ b/imports/ui/components/partyImage/partyImage.html
+@@ -0,0 +1 @@
++<img ng-src="{{partyImage.mainImage.url}}"/>
+-- 
+2.5.0
+
+
+From f215717543ef220d4659a675f84b3f82e2a6a30c Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 15:33:39 +0200
+Subject: [PATCH 340/356] Step 20.39: Create PartyImage component
+
+---
+ imports/ui/components/partyImage/partyImage.js | 37 ++++++++++++++++++++++++++
+ 1 file changed, 37 insertions(+)
+ create mode 100644 imports/ui/components/partyImage/partyImage.js
+
+diff --git a/imports/ui/components/partyImage/partyImage.js b/imports/ui/components/partyImage/partyImage.js
+new file mode 100644
+index 0000000..84e0bc6
+--- /dev/null
++++ b/imports/ui/components/partyImage/partyImage.js
+@@ -0,0 +1,37 @@
++import angular from 'angular';
++import angularMeteor from 'angular-meteor';
++
++import './partyImage.html';
++import { Images } from '../../../api/images';
++
++class PartyImage {
++  constructor($scope, $reactive) {
++    'ngInject';
++    $reactive(this).attach($scope);
++
++    this.helpers({
++      mainImage() {
++        const images = this.getReactively('images', true);
++        if (images) {
++          return Images.findOne({
++            _id: images[0]
++          });
++        }
++      }
++    });
++  }
++}
++
++const name = 'partyImage';
++
++// create a module
++export default angular.module(name, [
++  angularMeteor
++]).component(name, {
++  templateUrl: `imports/ui/components/${name}/${name}.html`,
++  bindings: {
++    images: '<'
++  },
++  controllerAs: name,
++  controller: PartyImage
++});
+-- 
+2.5.0
+
+
+From 52b7c3bd58ed154140dc8ea1f80aad67689b22c3 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 15:33:58 +0200
+Subject: [PATCH 341/356] Step 20.40: Implement PartyImage in PartiesList
+
+---
+ imports/ui/components/partiesList/partiesList.html | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/imports/ui/components/partiesList/partiesList.html b/imports/ui/components/partiesList/partiesList.html
+index 12987b3..de5d229 100644
+--- a/imports/ui/components/partiesList/partiesList.html
++++ b/imports/ui/components/partiesList/partiesList.html
+@@ -25,6 +25,11 @@
+             </span>
+             <span class="md-subhead">{{party.description}}</span>
+           </md-card-title-text>
++          <md-card-title-media ng-if="party.images">
++            <div class="md-media-lg card-media">
++              <party-image images="party.images"></party-image>
++            </div>
++          </md-card-title-media>
+         </md-card-title>
+         <md-card-content>
+           <party-rsvps-list rsvps="party.rsvps"></party-rsvps-list>
+-- 
+2.5.0
+
+
+From b2b3e343fbf9a5ead957191cdbf2a563f8c76115 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Wed, 13 Apr 2016 15:34:24 +0200
+Subject: [PATCH 342/356] Step 20.41: Add PartyImage to PartiesList and
+ subscribe to `images`
+
+---
+ imports/ui/components/partiesList/partiesList.js | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/imports/ui/components/partiesList/partiesList.js b/imports/ui/components/partiesList/partiesList.js
+index 92f56d3..ef9eb3c 100644
+--- a/imports/ui/components/partiesList/partiesList.js
++++ b/imports/ui/components/partiesList/partiesList.js
+@@ -14,6 +14,7 @@ import { name as PartyRemove } from '../partyRemove/partyRemove';
+ import { name as PartyCreator } from '../partyCreator/partyCreator';
+ import { name as PartyRsvp } from '../partyRsvp/partyRsvp';
+ import { name as PartyRsvpsList } from '../partyRsvpsList/partyRsvpsList';
++import { name as PartyImage } from '../partyImage/partyImage';
+ 
+ class PartiesList {
+   constructor($scope, $reactive) {
+@@ -36,6 +37,7 @@ class PartiesList {
+     ]);
+ 
+     this.subscribe('users');
++    this.subscribe('images');
+ 
+     this.helpers({
+       parties() {
+@@ -81,7 +83,8 @@ export default angular.module(name, [
+   PartyRemove,
+   PartyCreator,
+   PartyRsvp,
+-  PartyRsvpsList
++  PartyRsvpsList,
++  PartyImage
+ ]).component(name, {
+   templateUrl: `imports/ui/components/${name}/${name}.html`,
+   controllerAs: name,
+-- 
+2.5.0
+
+
+From 351258585d18cd64255283453ce1ce053f804326 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Thu, 14 Apr 2016 20:41:02 +0200
+Subject: [PATCH 343/356] Step 21.1: Add mobile platform
+
+---
+ .meteor/platforms | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/.meteor/platforms b/.meteor/platforms
+index efeba1b..0b0ddcc 100644
+--- a/.meteor/platforms
++++ b/.meteor/platforms
+@@ -1,2 +1,3 @@
+-server
++android
+ browser
++server
+-- 
+2.5.0
+
+
+From 16ab7e1d0d4addea55cad52c7476b257391590a9 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Thu, 14 Apr 2016 20:43:34 +0200
+Subject: [PATCH 344/356] Step 21.2: Move login.html to web.html
+
+---
+ imports/ui/components/login/web.html | 70 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 70 insertions(+)
+ create mode 100644 imports/ui/components/login/web.html
+
+diff --git a/imports/ui/components/login/web.html b/imports/ui/components/login/web.html
+new file mode 100644
+index 0000000..1ac5b6f
+--- /dev/null
++++ b/imports/ui/components/login/web.html
+@@ -0,0 +1,70 @@
++<md-content layout="row" layout-align="center start" layout-fill layout-margin>
++  <md-whiteframe layout="column" flex flex-md="50" flex-lg="50" flex-gt-lg="33" class="md-whiteframe-z2" layout-fill>
++    <md-toolbar class="md-primary md-tall" layout="column" layout-align="end" layout-fill>
++      <div layout="row" class="md-toolbar-tools md-toolbar-tools-bottom">
++        <h3 class="md-display-1">
++          Sign in
++        </h3>
++      </div>
++    </md-toolbar>
++
++    <div layout="column" layout-fill layout-margin layout-padding>
++      <div layout="row" layout-fill layout-margin>
++        <p class="md-body-2">
++          Use existing account</p>
++      </div>
++
++      <div layout="row" layout-fill layout-margin layout-padding layout-wrap>
++        <md-button class="md-raised">
++          <md-icon md-svg-icon="social:ic_google_24px" style="color: #DC4A38;"></md-icon>
++          <span>Google</span>
++        </md-button>
++        <md-button class="md-raised">
++          <md-icon md-svg-icon="social:ic_facebook_24px" style="color: #3F62B4;"></md-icon>
++          <span>Facebook</span>
++        </md-button>
++        <md-button class="md-raised">
++          <md-icon md-svg-icon="social:ic_twitter_24px" style="color: #27AAE2;"></md-icon>
++          <span>Twitter</span>
++        </md-button>
++      </div>
++      <md-divider class="inset"></md-divider>
++
++      <div layout="row" layout-fill layout-margin>
++        <p class="md-body-2">
++          Sign in with your email</p>
++      </div>
++
++      <form name="loginForm" layout="column" layout-fill layout-padding layout-margin>
++        <md-input-container>
++          <label>
++            Email
++          </label>
++          <input type="text" ng-model="login.credentials.email" aria-label="email" required/>
++        </md-input-container>
++        <md-input-container>
++          <label>
++            Password
++          </label>
++          <input type="password" ng-model="login.credentials.password" aria-label="password" required/>
++        </md-input-container>
++        <div layout="row" layout-align="space-between center">
++          <a class="md-button" href="/password">Forgot password?</a>
++          
++          <md-button class="md-raised md-primary" ng-click="login.login()" aria-label="login" ng-disabled="login.loginForm.$invalid()">Sign In
++          </md-button>
++        </div>
++      </form>
++
++      <md-toolbar ng-show="login.error" class="md-warn" layout="row" layout-fill layout-padding layout-margin>
++        <p class="md-body-1">{{ login.error }}</p>
++      </md-toolbar>
++
++      <md-divider></md-divider>
++
++      <div layout="row" layout-align="center">
++        <a class="md-button" href="/register">Need an account?</a>
++      </div>
++    </div>
++  </md-whiteframe>
++</md-content>
+-- 
+2.5.0
+
+
+From 9378d164932c7760624382e3ac0a8cd780ae16a8 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Thu, 14 Apr 2016 20:45:56 +0200
+Subject: [PATCH 345/356] Step 21.3: Add mobile view
+
+---
+ imports/ui/components/login/mobile.html | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+ create mode 100644 imports/ui/components/login/mobile.html
+
+diff --git a/imports/ui/components/login/mobile.html b/imports/ui/components/login/mobile.html
+new file mode 100644
+index 0000000..112ba9e
+--- /dev/null
++++ b/imports/ui/components/login/mobile.html
+@@ -0,0 +1,27 @@
++<md-content layout="row" layout-align="center start" layout-fill layout-margin>
++  <md-whiteframe layout="column" flex flex-md="50" flex-lg="50" flex-gt-lg="33" class="md-whiteframe-z2" layout-fill>
++    <!-- header -->
++    <md-toolbar class="md-primary md-tall" layout="column" layout-align="end" layout-fill>
++      <div layout="row" class="md-toolbar-tools md-toolbar-tools-bottom">
++        <h3 class="md-display-1">
++          Login
++        </h3>
++      </div>
++    </md-toolbar>
++
++    <!-- content -->
++    <div layout="column" layout-fill layout-margin layout-padding>
++      <!-- display an error -->
++      <md-toolbar ng-show="login.error" class="md-warn" layout="row" layout-fill layout-padding layout-margin>
++        <p class="md-body-1">{{ login.error }}</p>
++      </md-toolbar>
++
++      <md-divider></md-divider>
++
++      <!-- other actions -->
++      <div layout="row" layout-align="center">
++        <a class="md-button" href="/password">Forgot password?</a>
++      </div>
++    </div>
++  </md-whiteframe>
++</md-content>
+-- 
+2.5.0
+
+
+From 27bd9a3e1feeae0b511975a148b6e733b8d273a9 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Thu, 14 Apr 2016 20:47:15 +0200
+Subject: [PATCH 346/356] Step 21.4: Move Login class to web.js
+
+---
+ imports/ui/components/login/web.js | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+ create mode 100644 imports/ui/components/login/web.js
+
+diff --git a/imports/ui/components/login/web.js b/imports/ui/components/login/web.js
+new file mode 100644
+index 0000000..bc7b752
+--- /dev/null
++++ b/imports/ui/components/login/web.js
+@@ -0,0 +1,30 @@
++import { Meteor } from 'meteor/meteor';
++
++export class Login {
++  constructor($scope, $reactive, $state) {
++    'ngInject';
++
++    this.$state = $state;
++
++    $reactive(this).attach($scope);
++
++    this.credentials = {
++      email: '',
++      password: ''
++    };
++
++    this.error = '';
++  }
++
++  login() {
++    Meteor.loginWithPassword(this.credentials.email, this.credentials.password,
++      this.$bindToContext((err) => {
++        if (err) {
++          this.error = err;
++        } else {
++          this.$state.go('parties');
++        }
++      })
++    );
++  }
++}
+-- 
+2.5.0
+
+
+From 20ab509847c0763a27b84feabdbc3c6073a870d4 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Thu, 14 Apr 2016 20:48:39 +0200
+Subject: [PATCH 347/356] Step 21.5: Create controller for mobile
+
+---
+ imports/ui/components/login/mobile.js | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 imports/ui/components/login/mobile.js
+
+diff --git a/imports/ui/components/login/mobile.js b/imports/ui/components/login/mobile.js
+new file mode 100644
+index 0000000..792f38c
+--- /dev/null
++++ b/imports/ui/components/login/mobile.js
+@@ -0,0 +1 @@
++export class Login {}
+-- 
+2.5.0
+
+
+From 256679e260d15eebdd18596f742b8d09d4474066 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Thu, 14 Apr 2016 20:49:48 +0200
+Subject: [PATCH 348/356] Step 21.6: Refactor login.js
+
+---
+ imports/ui/components/login/login.js | 42 +++++++-----------------------------
+ 1 file changed, 8 insertions(+), 34 deletions(-)
+
+diff --git a/imports/ui/components/login/login.js b/imports/ui/components/login/login.js
+index f5a3be4..e1b3a29 100644
+--- a/imports/ui/components/login/login.js
++++ b/imports/ui/components/login/login.js
+@@ -4,40 +4,14 @@ import uiRouter from 'angular-ui-router';
+ 
+ import { Meteor } from 'meteor/meteor';
+ 
+-import './login.html';
+-
+-import { name as Register } from '../register/register';
+-
+-class Login {
+-  constructor($scope, $reactive, $state) {
+-    'ngInject';
+-
+-    this.$state = $state;
+-
+-    $reactive(this).attach($scope);
+-
+-    this.credentials = {
+-      email: '',
+-      password: ''
+-    };
+-
+-    this.error = '';
+-  }
+-
+-  login() {
+-    Meteor.loginWithPassword(this.credentials.email, this.credentials.password,
+-      this.$bindToContext((err) => {
+-        if (err) {
+-          this.error = err;
+-        } else {
+-          this.$state.go('parties');
+-        }
+-      })
+-    );
+-  }
+-}
++import './web.html';
++import { Login as LoginWeb } from './web';
++import './mobile.html';
++import { Login as LoginMobile } from './mobile';
+ 
+ const name = 'login';
++const template = Meteor.isCordova ? 'mobile' : 'web';
++const controller = Meteor.isCordova ? LoginMobile : LoginWeb;
+ 
+ // create a module
+ export default angular.module(name, [
+@@ -45,9 +19,9 @@ export default angular.module(name, [
+   uiRouter
+ ])
+   .component(name, {
+-    templateUrl: `imports/ui/components/${name}/${name}.html`,
++    controller,
+     controllerAs: name,
+-    controller: Login
++    templateUrl: `imports/ui/components/${name}/${template}.html`,
+   })
+   .config(config);
+ 
+-- 
+2.5.0
+
+
+From 94577acf2f82225361233bf99b79d1991e822706 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Thu, 14 Apr 2016 20:50:03 +0200
+Subject: [PATCH 349/356] Step 21.7: Remove login.html
+
+---
+ imports/ui/components/login/login.html | 72 ----------------------------------
+ 1 file changed, 72 deletions(-)
+ delete mode 100644 imports/ui/components/login/login.html
+
+diff --git a/imports/ui/components/login/login.html b/imports/ui/components/login/login.html
+deleted file mode 100644
+index 64ea544..0000000
+--- a/imports/ui/components/login/login.html
++++ /dev/null
+@@ -1,72 +0,0 @@
+-<md-content layout="row" layout-align="center start" layout-fill layout-margin>
+-
+-  <md-whiteframe layout="column" flex flex-md="50" flex-lg="50" flex-gt-lg="33" class="md-whiteframe-z2" layout-fill>
+-
+-    <md-toolbar class="md-primary md-tall" layout="column" layout-align="end" layout-fill>
+-      <div layout="row" class="md-toolbar-tools md-toolbar-tools-bottom">
+-        <h3 class="md-display-1">
+-          Sign in
+-        </h3>
+-      </div>
+-    </md-toolbar>
+-
+-    <div layout="column" layout-fill layout-margin layout-padding>
+-      <div layout="row" layout-fill layout-margin>
+-        <p class="md-body-2">
+-          Use existing account</p>
+-      </div>
+-      <div layout="row" layout-fill layout-margin layout-padding layout-wrap>
+-        <md-button class="md-raised">
+-          <md-icon md-svg-icon="social:ic_google_24px" style="color: #DC4A38;"></md-icon>
+-          <span>
+-            Google</span>
+-        </md-button>
+-        <md-button class="md-raised">
+-          <md-icon md-svg-icon="social:ic_facebook_24px" style="color: #3F62B4;"></md-icon>
+-          <span>Facebook
+-          </span>
+-        </md-button>
+-        <md-button class="md-raised">
+-          <md-icon md-svg-icon="social:ic_twitter_24px" style="color: #27AAE2;"></md-icon>
+-          <span>Twitter
+-          </span>
+-        </md-button>
+-      </div>
+-      <md-divider class="inset"></md-divider>
+-
+-      <div layout="row" layout-fill layout-margin>
+-        <p class="md-body-2">
+-          Sign in with your email</p>
+-      </div>
+-
+-      <form name="loginForm" layout="column" layout-fill layout-padding layout-margin>
+-        <md-input-container>
+-          <label>
+-            Email
+-          </label>
+-          <input type="text" ng-model="login.credentials.email" aria-label="email" required/>
+-        </md-input-container>
+-        <md-input-container>
+-          <label>
+-            Password
+-          </label>
+-          <input type="password" ng-model="login.credentials.password" aria-label="password" required/>
+-        </md-input-container>
+-        <div layout="row" layout-align="space-between center">
+-          <a class="md-button" href="/password">Forgot password?</a>
+-          <md-button class="md-raised md-primary" ng-click="login.login()" aria-label="login" ng-disabled="login.loginForm.$invalid()">Sign In
+-          </md-button>
+-        </div>
+-      </form>
+-      <md-toolbar ng-show="login.error" class="md-warn" layout="row" layout-fill layout-padding layout-margin>
+-        <p class="md-body-1">{{ login.error }}</p>
+-      </md-toolbar>
+-      <md-divider></md-divider>
+-      <div layout="row" layout-align="center">
+-        <a class="md-button" href="/register">Need an account?</a>
+-      </div>
+-
+-    </div>
+-
+-  </md-whiteframe>
+-</md-content>
+-- 
+2.5.0
+
+
+From ff205217b722cfb15c06d8a3eda7ad2a1dd0e1e7 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Thu, 14 Apr 2016 20:52:54 +0200
+Subject: [PATCH 350/356] Step 21.8: Add `okland:accounts-phone`
+
+---
+ .meteor/packages | 1 +
+ .meteor/versions | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/.meteor/packages b/.meteor/packages
+index 57c1f6b..e6717e6 100644
+--- a/.meteor/packages
++++ b/.meteor/packages
+@@ -31,3 +31,4 @@ less
+ planettraining:material-design-icons
+ jalik:ufs
+ jalik:ufs-gridfs
++mys:accounts-phone
+diff --git a/.meteor/versions b/.meteor/versions
+index abe42a2..45162cd 100644
+--- a/.meteor/versions
++++ b/.meteor/versions
+@@ -68,6 +68,7 @@ oauth@1.1.8
+ oauth1@1.1.7
+ oauth2@1.1.7
+ observe-sequence@1.0.11
++mys:accounts-phone@0.0.21
+ ordered-dict@1.0.7
+ pbastowski:angular-babel@1.3.2
+ planettraining:material-design-icons@2.2.0
+-- 
+2.5.0
+
+
+From 081cd7032a5b128d08f324214dc808a78772c69c Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Thu, 14 Apr 2016 20:56:24 +0200
+Subject: [PATCH 351/356] Step 21.9: Add phone verification method
+
+---
+ imports/ui/components/login/mobile.js | 28 +++++++++++++++++++++++++++-
+ 1 file changed, 27 insertions(+), 1 deletion(-)
+
+diff --git a/imports/ui/components/login/mobile.js b/imports/ui/components/login/mobile.js
+index 792f38c..c201eb2 100644
+--- a/imports/ui/components/login/mobile.js
++++ b/imports/ui/components/login/mobile.js
+@@ -1 +1,27 @@
+-export class Login {}
++import { Accounts } from 'meteor/accounts-base';
++
++export class Login {
++  constructor($scope, $reactive) {
++    'ngInject';
++
++    $reactive(this).attach($scope);
++
++    this.isStepTwo = false;
++    this.phoneNumber = '';
++    this.verificationCode = '';
++    this.error = '';
++  }
++
++  verifyPhone() {
++    Accounts.requestPhoneVerification(this.phoneNumber, this.$bindToContext((err) => {
++      if (err) {
++        // display also reason of Meteor.Error
++        this.error = err.reason || err;
++      } else {
++        this.error = '';
++        // move to code verification
++        this.isStepTwo = true;
++      }
++    }));
++  }
++}
+-- 
+2.5.0
+
+
+From 363476ab8564b3ae59924d0edbbff7f385a1cfbc Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Thu, 14 Apr 2016 20:57:40 +0200
+Subject: [PATCH 352/356] Step 21.10: Add phone verification form
+
+---
+ imports/ui/components/login/mobile.html | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/imports/ui/components/login/mobile.html b/imports/ui/components/login/mobile.html
+index 112ba9e..0b889a7 100644
+--- a/imports/ui/components/login/mobile.html
++++ b/imports/ui/components/login/mobile.html
+@@ -4,13 +4,22 @@
+     <md-toolbar class="md-primary md-tall" layout="column" layout-align="end" layout-fill>
+       <div layout="row" class="md-toolbar-tools md-toolbar-tools-bottom">
+         <h3 class="md-display-1">
+-          Login
++          Login with SMS
+         </h3>
+       </div>
+     </md-toolbar>
+ 
+     <!-- content -->
+     <div layout="column" layout-fill layout-margin layout-padding>
++      <!-- step 1: phone verification -->
++      <form ng-show="!login.isStepTwo" layout="column" layout-fill layout-padding layout-margin>
++        <md-input-container>
++          <input type="text" ng-model="login.phoneNumber" placeholder="phone"/>
++        </md-input-container>
++        <md-button class="md-raised md-primary" ng-click="login.verifyPhone()" aria-label="login" ng-disabled="!login.phoneNumber">Send SMS
++        </md-button>
++      </form>
++      
+       <!-- display an error -->
+       <md-toolbar ng-show="login.error" class="md-warn" layout="row" layout-fill layout-padding layout-margin>
+         <p class="md-body-1">{{ login.error }}</p>
+-- 
+2.5.0
+
+
+From 827b2c4a4ff9abc5864af8e361b07767508ef414 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Thu, 14 Apr 2016 21:00:05 +0200
+Subject: [PATCH 353/356] Step 21.11: Add code verification method
+
+---
+ imports/ui/components/login/mobile.js | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/imports/ui/components/login/mobile.js b/imports/ui/components/login/mobile.js
+index c201eb2..798d563 100644
+--- a/imports/ui/components/login/mobile.js
++++ b/imports/ui/components/login/mobile.js
+@@ -1,9 +1,11 @@
+ import { Accounts } from 'meteor/accounts-base';
+ 
+ export class Login {
+-  constructor($scope, $reactive) {
++  constructor($scope, $reactive, $state) {
+     'ngInject';
+ 
++    this.$state = $state;
++
+     $reactive(this).attach($scope);
+ 
+     this.isStepTwo = false;
+@@ -24,4 +26,15 @@ export class Login {
+       }
+     }));
+   }
++
++  verifyCode() {
++    Accounts.verifyPhone(this.phoneNumber, this.verificationCode, this.$bindToContext((err) => {
++      if (err) {
++        this.error = err.reason || err;
++      } else {
++        // redirect to parties list
++        this.$state.go('parties');
++      }
++    }));
++  }
+ }
+-- 
+2.5.0
+
+
+From 60db5dcbdd2bb23a9dc331d7f976c2ac201c1450 Mon Sep 17 00:00:00 2001
+From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
+Date: Thu, 14 Apr 2016 21:01:13 +0200
+Subject: [PATCH 354/356] Step 21.12: Add code verification form
+
+---
+ imports/ui/components/login/mobile.html | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/imports/ui/components/login/mobile.html b/imports/ui/components/login/mobile.html
+index 0b889a7..e93c1d5 100644
+--- a/imports/ui/components/login/mobile.html
++++ b/imports/ui/components/login/mobile.html
+@@ -19,7 +19,15 @@
+         <md-button class="md-raised md-primary" ng-click="login.verifyPhone()" aria-label="login" ng-disabled="!login.phoneNumber">Send SMS
+         </md-button>
+       </form>
+-      
++      <!-- step 2: code verification -->
++      <form ng-show="login.isStepTwo" layout="column" layout-fill layout-padding layout-margin>
++        <md-input-container>
++          <input type="text" ng-model="login.verificationCode" placeholder="code"/>
++        </md-input-container>
++        <md-button class="md-raised md-primary" ng-click="login.verifyCode()" aria-label="login" ng-disabled="!login.verificationCode">Verify Code
++        </md-button>
++      </form>
++
+       <!-- display an error -->
+       <md-toolbar ng-show="login.error" class="md-warn" layout="row" layout-fill layout-padding layout-margin>
+         <p class="md-body-1">{{ login.error }}</p>
+-- 
+2.5.0
+
+
+From 724874cfdb618fb866c9641a748a8c51c1e7e68b Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 10:27:29 +0200
-Subject: [PATCH 302/303] Add README
+Subject: [PATCH 355/356] Add README
 
 ---
  README.md | 61 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -10877,10 +12910,10 @@ index 0000000..95fd557
 2.5.0
 
 
-From eb7c9a46b8c9c2f6f89f12e4da6015008b3719f7 Mon Sep 17 00:00:00 2001
+From e989cab647e4f64b3118d57c19c5141ec6c80a53 Mon Sep 17 00:00:00 2001
 From: Kamil Kisiela <kamil.kisiela@ster-project.pl>
 Date: Mon, 11 Apr 2016 10:28:34 +0200
-Subject: [PATCH 303/303] Add EDIT_THIS_TUTORIAL.md
+Subject: [PATCH 356/356] Add EDIT_THIS_TUTORIAL.md
 
 ---
  EDIT_THIS_TUTORIAL.md | 192 ++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
- Adds steps: 20, 21.
- Replaces `bootstrap4-webpack-package` with `bootstrap` thanks to Meteor 1.3.2
- Updates `sanjo:jasmine` to `1.0.1` with a fix for #37 

_To do after approval_:
- [x] Update Socially to use `1.3.2`
- [x] Push changes to `meteor-angular-socially`
- [x] Update tag `step_19`
- [x] Add tag `step_20`
- [x] Add tag `step_21`
