### PR TITLE
remove /meteor_component

### DIFF
--- a/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_08.md
+++ b/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_08.md
@@ -114,7 +114,7 @@ If you place `@InjectUser` above the PartiesForm it will inject a new user prope
 __`client/parties-form/parties-form.ts`__:
 
     ...
-    import {MeteorComponent} from 'angular2-meteor/meteor_component';
+    import {MeteorComponent} from 'angular2-meteor';
     import {InjectUser} from 'angular2-meteor-accounts-ui';
 
     @Component({


### PR DESCRIPTION
After updating angular2-meteor from 0.5.2 to 0.5.3
`import { MeteorComponent } from 'angular2-meteor/meteor_component';`
needs change to
`import { MeteorComponent } from 'angular2-meteor';`
