### PR TITLE
Changed --ambient to --global

### DIFF
--- a/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_00.md
+++ b/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_00.md
@@ -117,11 +117,11 @@ and management called `typings`. You can find more information about it [here](h
 
 In our case, we'll need to execute commands as follows to install all dependencies:
 
-        $ npm install typings -g
+        $ sudo npm install typings -g
         $ typings init
         $ typings install es6-promise --save
-        $ typings install es6-shim --ambient --save
-        $ typings install registry:env/meteor --ambient
+        $ typings install dt~es6-shim --global --save
+        $ typings install registry:env/meteor --global
 
 If you look into the typings folder after the execution, you'll find there a definition file called `main.d.ts`.
 

--- a/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_00.md
+++ b/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_00.md
@@ -123,7 +123,7 @@ In our case, we'll need to execute commands as follows to install all dependenci
         $ typings install dt~es6-shim --global --save
         $ typings install registry:env/meteor --global
 
-If you look into the typings folder after the execution, you'll find there a definition file called `main.d.ts`.
+If you look into the typings folder after the execution, you'll find there a definition file called `index.d.ts`.
 
 This is a top level definition file that links all other definition files installed by `typings`.
 


### PR DESCRIPTION
According to release notes at https://github.com/typings/typings, and my recent experience --ambient does not work anymore.
Also one have to explicitly add `dt~` prefix to specify that definitions should be downloaded from the DefinitelyTyped repo.
It seems to me that npm install typings -g requires sudo, to be able to create symlink to typings in to /usr/local/bin.
I'm also not sure why the last command does not have --save switch - if it's on purpose, then it should be explained in the tutorial for people like me:)
