### PR TITLE
The "Login" menu appears below, not to the right of Add

### DIFF
--- a/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_08.md
+++ b/client/content/tutorials/socially/angular2/tutorials.socially.angular2.step_08.md
@@ -41,11 +41,11 @@ Add the "accounts-password" Meteor package. It's a very powerful package for all
 
     $ meteor add accounts-password
 
-Now we are going to add `angular2-meteor-accounts-ui` which is a which is a package that contains all the HTML and CSS we need for the user operation forms.
+Now we are going to add `angular2-meteor-accounts-ui` which is a package that contains all the HTML and CSS we need for the user operation forms.
 
     $ meteor npm install --save angular2-meteor-accounts-ui
 
-Let's add the `<login-buttons>` tag to the right of the party form in the PartiesList's template:
+Let's add the `<login-buttons>` tag below of the party form in the PartiesList's template:
 
 {{> DiffBox tutorialName="meteor-angular2-socially" step="8.2"}}
 
@@ -63,7 +63,7 @@ And now let's create main stylesheet file (with `.scss` extension), and import t
 
 {{> DiffBox tutorialName="meteor-angular2-socially" step="8.4"}}
 
-Run the code, you'll see a login link to the right of the "Add" button. Click on the link and then "create  account" to sign up. Try to log in and log out.
+Run the code, you'll see a login link below the form. Click on the link and then "create  account" to sign up. Try to log in and log out.
 
 That's it! As you can see, it's very easy to add basic login support with the help of the Meteor accounts package.
 


### PR DESCRIPTION
The `<form>` tag defaults to `display:block` and causes the login menu to appear in the next line, even though `.login-buttons` have `display:inline-block` style assigned.
At this point I'm becoming more and more inclined to believe that the whole tutorial is missing some "general style rules", which would explain while all the pages so far looked so ugly, and why the author expects the login menu to appear on the right - perhaps someone forgot to mention earlier in the tutorial that I was supposed to copy&paste some styles, or install materials design, or bootstrap or something?
One of the things I very much liked about the original, official, Metor tutorial (the one that made me build a simple TODO-app), was that it loooked pretty from step 1. This might seem naive of me, but such details as aesthetics, play some subconscious role in decision making, and I've still haven't made my mind about whether or not to use angular2-meteor in my next project.
